### PR TITLE
feat: add Venmo vault flow for editing payment method

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -47,6 +47,8 @@
       <button id="toggle-plans">Toggle plans</button>
       <button id="toggle-prefilled-email">Toggle pre-filled email</button>
       <button id="toggle-edit-payment-method">Toggle edit payment method</button>
+      <button id="mock-venmo-success">Mock Venmo success</button>
+      <button id="mock-venmo-error">Mock Venmo error</button>
 
       <br>
       <input type="checkbox" id="force-successful-requests" name="force-successful-requests">
@@ -501,6 +503,42 @@
     document.getElementById('toggle-edit-payment-method').addEventListener('click', async () => {
       mgcComponent.canEditPaymentMethod = !mgcComponent.canEditPaymentMethod;
       await mgcComponent.updateComplete;
+    });
+
+    // --- Venmo mocks ---
+    // These fire the same events that the real Braintree Venmo SDK fires on
+    // <ia-mgc-braintree-manager>, so payment-method.ts handles them identically.
+    // Open a plan in edit mode and select Venmo before clicking.
+
+    document.getElementById('mock-venmo-success').addEventListener('click', () => {
+      const bt = document.querySelector('ia-mgc-braintree-manager');
+      if (!bt) {
+        uxMessageInfoArea.innerText = 'No braintree manager found — open a plan in edit mode first.';
+        return;
+      }
+      bt.dispatchEvent(new CustomEvent('VenmoAuthorized', {
+        detail: {
+          paymentMethodInfo: {
+            description: 'Venmo - @mock_venmo_user',
+            nonce: `mock-venmo-nonce-${Date.now()}`,
+            type: 'VenmoAccount',
+            details: { username: 'mock_venmo_user' },
+          },
+        },
+      }));
+      uxMessageInfoArea.innerText = 'Mock VenmoAuthorized event dispatched.';
+    });
+
+    document.getElementById('mock-venmo-error').addEventListener('click', () => {
+      const bt = document.querySelector('ia-mgc-braintree-manager');
+      if (!bt) {
+        uxMessageInfoArea.innerText = 'No braintree manager found — open a plan in edit mode first.';
+        return;
+      }
+      bt.dispatchEvent(new CustomEvent('VenmoError', {
+        detail: { error: { code: 'VENMO_MOCK_ERROR', message: 'Mock Venmo error for demo' } },
+      }));
+      uxMessageInfoArea.innerText = 'Mock VenmoError event dispatched.';
     });
   </script>
 </body>

--- a/demo/index.html
+++ b/demo/index.html
@@ -426,17 +426,27 @@
       console.log('UpdatePaymentMethod received:', e.detail);
       const { plan, newPaymentMethodRequest } = e.detail;
 
-      const isPayPal = newPaymentMethodRequest?.paymentProvider === 'PayPal';
-      const heads = isPayPal ? true : flipCoin() === 1;
+      const provider = newPaymentMethodRequest?.paymentProvider;
+      const isPayPal = provider === 'PayPal';
+      const isVenmo = provider === 'Venmo';
+
+      // PayPal always succeeds in demo; Venmo always succeeds; CC is coin-flip
+      const heads = (isPayPal || isVenmo) ? true : flipCoin() === 1;
       const successOrFail = heads ? 'success' : 'fail';
       const returnTiming = heads ? 1500 : 4000;
 
-      const paypalEmail = newPaymentMethodRequest?.paymentMethodInfo?.details?.email;
-      const paypalNonce = newPaymentMethodRequest?.paymentMethodInfo?.nonce;
-      const methodLabel = isPayPal
-        ? `PayPal (${paypalEmail}, nonce: ${paypalNonce})`
-        : 'payment method';
-      uxMessageInfoArea.innerText = `Updating ${methodLabel} for plan: ${plan ? plan.id : 'no plan'} -- Update will return ${successOrFail} in ${returnTiming} ms`;
+      const details = newPaymentMethodRequest?.paymentMethodInfo?.details;
+      const nonce = newPaymentMethodRequest?.paymentMethodInfo?.nonce;
+      let methodLabel;
+      if (isPayPal) {
+        methodLabel = `PayPal (${details?.email}, nonce: ${nonce})`;
+      } else if (isVenmo) {
+        methodLabel = `Venmo (@${details?.username}, nonce: ${nonce})`;
+      } else {
+        methodLabel = 'Credit Card';
+      }
+
+      uxMessageInfoArea.innerText = `Updating ${methodLabel} for plan: ${plan ? plan.id : 'no plan'} — will return ${successOrFail} in ${returnTiming} ms`;
       const message = successOrFail === 'success' ? 'Payment method updated' : 'Payment method failed to update';
 
       if (heads && plan) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/donation-monthly-portal",
-  "version": "0.0.0-venmo-3",
+  "version": "7.7.0",
   "description": "The Internet Archive Monthly Portal",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/donation-monthly-portal",
-  "version": "7.7.0",
+  "version": "0.0.0-venmo-3",
   "description": "The Internet Archive Monthly Portal",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",

--- a/src/edit-plan-form.ts
+++ b/src/edit-plan-form.ts
@@ -6,6 +6,7 @@ import '@internetarchive/donation-form/dist/src/form-elements/badged-input';
 import { HostingEnvironment } from '@internetarchive/donation-form';
 import type { PaymentConfig } from './form-sections/parts/braintree-manager';
 import type { MonthlyPlan } from './models/plan';
+import { VenmoPendingStorage } from './utils/venmo-pending-storage';
 import './form-sections/amount';
 import './form-sections/date';
 import './form-sections/cancel';
@@ -31,6 +32,9 @@ export class IauxEditPlanForm extends LitElement {
       feeCovered: number;
     },
   ) => void;
+
+  @property({ type: Object }) venmoPendingStorage: VenmoPendingStorage =
+    new VenmoPendingStorage();
 
   @property({ type: Object }) paymentConfig: PaymentConfig = {
     referrer: '',
@@ -98,6 +102,7 @@ export class IauxEditPlanForm extends LitElement {
                 .plan=${this.plan}
                 .patronEmail=${this.patronEmail}
                 .paymentConfig=${this.paymentConfig}
+                .venmoPendingStorage=${this.venmoPendingStorage}
                 @UpdatePaymentMethod=${(e: CustomEvent) => {
                   const { newPaymentMethodRequest } = e.detail;
                   if (this.plan) {

--- a/src/edit-plan-form.ts
+++ b/src/edit-plan-form.ts
@@ -6,7 +6,7 @@ import '@internetarchive/donation-form/dist/src/form-elements/badged-input';
 import { HostingEnvironment } from '@internetarchive/donation-form';
 import type { PaymentConfig } from './form-sections/parts/braintree-manager';
 import type { MonthlyPlan } from './models/plan';
-import { VenmoPendingStorage } from './utils/venmo-pending-storage';
+import type { VenmoPendingStorage } from './utils/venmo-pending-storage';
 import './form-sections/amount';
 import './form-sections/date';
 import './form-sections/cancel';
@@ -33,8 +33,7 @@ export class IauxEditPlanForm extends LitElement {
     },
   ) => void;
 
-  @property({ type: Object }) venmoPendingStorage: VenmoPendingStorage =
-    new VenmoPendingStorage();
+  @property({ type: Object }) venmoPendingStorage?: VenmoPendingStorage;
 
   @property({ type: Object }) paymentConfig: PaymentConfig = {
     referrer: '',

--- a/src/form-sections/parts/braintree-manager.ts
+++ b/src/form-sections/parts/braintree-manager.ts
@@ -475,9 +475,13 @@ export class MGCBraintreeManager extends LitElement {
     // suppress Google Pay, so we replace the handler directly. The upstream path
     // is `BraintreeManager.paymentProviders.googlePayHandler` — if that changes
     // this cast will silently stop working and the button may reappear.
-    if (!this.paymentConfig?.googlePayMerchantId) {
+    if (!this.paymentConfig?.googlePayMerchantId && this.braintreeManager) {
+      // BraintreeManager has no config option to suppress Google Pay, so we
+      // replace the handler directly. Casting only paymentProviders (not the
+      // whole manager) keeps the access chain type-checked — if upstream
+      // renames paymentProviders or googlePayHandler, TypeScript will catch it.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (this.braintreeManager as any).paymentProviders.googlePayHandler = {
+      (this.braintreeManager.paymentProviders as any).googlePayHandler = {
         get: async () => null,
       };
     }

--- a/src/form-sections/parts/braintree-manager.ts
+++ b/src/form-sections/parts/braintree-manager.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { LitElement, html, css, CSSResult, PropertyValueMap } from 'lit';
+import { LitElement, html, nothing, css, CSSResult, PropertyValueMap } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 import {
@@ -49,6 +49,8 @@ export class MGCBraintreeManager extends LitElement {
   @property({ type: Object }) braintreeManager?: BraintreeManagerInterface;
 
   @state() private elementConnected: boolean = false;
+
+  @property({ type: Boolean }) displayVenmo: boolean = false;
 
   get braintreeInputs(): {
     errorMessage: HTMLDivElement | null;
@@ -204,7 +206,17 @@ export class MGCBraintreeManager extends LitElement {
   }
 
   render() {
-    return html` <div>${this.creditCardTemplate}</div> `;
+    return html`
+      <div>${this.creditCardTemplate}</div>
+      ${this.displayVenmo
+        ? html`<button
+            id="ia-mgc-venmo-button"
+            @click=${this.startVenmoPayment}
+          >
+            Pay with Venmo
+          </button>`
+        : nothing}
+    `;
   }
 
   lightDomCSS(): CSSResult {
@@ -319,6 +331,37 @@ export class MGCBraintreeManager extends LitElement {
         },
       }),
     );
+  }
+
+  private async startVenmoPayment(): Promise<void> {
+    const handler =
+      await this.braintreeManager?.paymentProviders.venmoHandler.get();
+    if (!handler) return;
+
+    try {
+      const payload = await handler.startPayment();
+      this.dispatchEvent(
+        new CustomEvent('VenmoAuthorized', {
+          detail: {
+            paymentMethodInfo: {
+              description: `Venmo - ${payload.details.username}`,
+              nonce: payload.nonce,
+              type: payload.type,
+              details: { username: payload.details.username },
+            },
+          },
+        }),
+      );
+    } catch (e: any) {
+      if (e?.code === 'VENMO_APP_CANCELED' || e?.code === 'VENMO_CANCELED') {
+        console.log('Venmo payment cancelled');
+      } else {
+        console.error('Venmo payment error:', e);
+        this.dispatchEvent(
+          new CustomEvent('VenmoError', { detail: { error: e } }),
+        );
+      }
+    }
   }
 
   private async setupBraintreeManager(): Promise<void> {

--- a/src/form-sections/parts/braintree-manager.ts
+++ b/src/form-sections/parts/braintree-manager.ts
@@ -51,8 +51,7 @@ export class MGCBraintreeManager extends LitElement {
 
   @state() private elementConnected: boolean = false;
 
-  @property({ type: Object }) venmoPendingStorage: VenmoPendingStorage =
-    new VenmoPendingStorage();
+  @property({ type: Object }) venmoPendingStorage?: VenmoPendingStorage;
 
   get braintreeInputs(): {
     errorMessage: HTMLDivElement | null;
@@ -330,11 +329,11 @@ export class MGCBraintreeManager extends LitElement {
       await this.braintreeManager?.paymentProviders.venmoHandler.get();
     if (!handler) return;
 
-    if (this.plan?.id) this.venmoPendingStorage.setPending(this.plan.id);
+    if (this.plan?.id) this.venmoPendingStorage?.setPending(this.plan.id);
 
     try {
       const payload = await handler.startPayment();
-      if (this.plan?.id) this.venmoPendingStorage.clearPending(this.plan.id);
+      if (this.plan?.id) this.venmoPendingStorage?.clearPending(this.plan.id);
       this.dispatchEvent(
         new CustomEvent('VenmoAuthorized', {
           detail: {
@@ -348,7 +347,7 @@ export class MGCBraintreeManager extends LitElement {
         }),
       );
     } catch (e: unknown) {
-      if (this.plan?.id) this.venmoPendingStorage.clearPending(this.plan.id);
+      if (this.plan?.id) this.venmoPendingStorage?.clearPending(this.plan.id);
       const code = (e as { code?: string })?.code;
       if (code === 'VENMO_APP_CANCELED' || code === 'VENMO_CANCELED') {
         console.log('Venmo payment cancelled');
@@ -364,24 +363,24 @@ export class MGCBraintreeManager extends LitElement {
   private async checkVenmoRestoration(): Promise<void> {
     const planId = this.plan?.id;
     if (!planId) return;
-    const pending = this.venmoPendingStorage.getPending(planId);
+    const pending = this.venmoPendingStorage?.getPending(planId);
     if (!pending) return;
 
     const handler =
       await this.braintreeManager?.paymentProviders.venmoHandler.get();
     if (!handler) {
-      this.venmoPendingStorage.clearPending(planId);
+      this.venmoPendingStorage?.clearPending(planId);
       return;
     }
 
     const instance = await handler.instance.get();
     if (!instance) {
-      this.venmoPendingStorage.clearPending(planId);
+      this.venmoPendingStorage?.clearPending(planId);
       return;
     }
 
     // Clear before tokenizing to prevent retry loops on failure
-    this.venmoPendingStorage.clearPending(planId);
+    this.venmoPendingStorage?.clearPending(planId);
 
     if (!instance.hasTokenizationResult()) return;
 

--- a/src/form-sections/parts/braintree-manager.ts
+++ b/src/form-sections/parts/braintree-manager.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { LitElement, html, nothing, css, CSSResult, PropertyValueMap } from 'lit';
+import { LitElement, html, css, CSSResult, PropertyValueMap } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 import {
@@ -21,6 +21,7 @@ import type { PaymentClientsInterface } from '@internetarchive/donation-form/dis
 import creditCardImg from '@internetarchive/icon-credit-card/index.js';
 import calendarImg from '@internetarchive/icon-calendar/index.js';
 import lockImg from '@internetarchive/icon-lock/index.js';
+import { VenmoPendingStorage } from '../../utils/venmo-pending-storage';
 
 import type { MonthlyPlan } from '../../models/plan';
 
@@ -50,7 +51,8 @@ export class MGCBraintreeManager extends LitElement {
 
   @state() private elementConnected: boolean = false;
 
-  @property({ type: Boolean }) displayVenmo: boolean = false;
+  @property({ type: Object }) venmoPendingStorage: VenmoPendingStorage =
+    new VenmoPendingStorage();
 
   get braintreeInputs(): {
     errorMessage: HTMLDivElement | null;
@@ -206,17 +208,7 @@ export class MGCBraintreeManager extends LitElement {
   }
 
   render() {
-    return html`
-      <div>${this.creditCardTemplate}</div>
-      ${this.displayVenmo
-        ? html`<button
-            id="ia-mgc-venmo-button"
-            @click=${this.startVenmoPayment}
-          >
-            Pay with Venmo
-          </button>`
-        : nothing}
-    `;
+    return html` <div>${this.creditCardTemplate}</div> `;
   }
 
   lightDomCSS(): CSSResult {
@@ -333,10 +325,64 @@ export class MGCBraintreeManager extends LitElement {
     );
   }
 
-  private async startVenmoPayment(): Promise<void> {
+  async startVenmoPayment(): Promise<void> {
     const handler =
       await this.braintreeManager?.paymentProviders.venmoHandler.get();
     if (!handler) return;
+
+    if (this.plan?.id) this.venmoPendingStorage.setPending(this.plan.id);
+
+    try {
+      const payload = await handler.startPayment();
+      if (this.plan?.id) this.venmoPendingStorage.clearPending(this.plan.id);
+      this.dispatchEvent(
+        new CustomEvent('VenmoAuthorized', {
+          detail: {
+            paymentMethodInfo: {
+              description: `Venmo - ${payload.details.username}`,
+              nonce: payload.nonce,
+              type: payload.type,
+              details: { username: payload.details.username },
+            },
+          },
+        }),
+      );
+    } catch (e: any) {
+      if (this.plan?.id) this.venmoPendingStorage.clearPending(this.plan.id);
+      if (e?.code === 'VENMO_APP_CANCELED' || e?.code === 'VENMO_CANCELED') {
+        console.log('Venmo payment cancelled');
+      } else {
+        console.error('Venmo payment error:', e);
+        this.dispatchEvent(
+          new CustomEvent('VenmoError', { detail: { error: e } }),
+        );
+      }
+    }
+  }
+
+  private async checkVenmoRestoration(): Promise<void> {
+    const planId = this.plan?.id;
+    if (!planId) return;
+    const pending = this.venmoPendingStorage.getPending(planId);
+    if (!pending) return;
+
+    const handler =
+      await this.braintreeManager?.paymentProviders.venmoHandler.get();
+    if (!handler) {
+      this.venmoPendingStorage.clearPending(planId);
+      return;
+    }
+
+    const instance = await handler.instance.get();
+    if (!instance) {
+      this.venmoPendingStorage.clearPending(planId);
+      return;
+    }
+
+    // Clear before tokenizing to prevent retry loops on failure
+    this.venmoPendingStorage.clearPending(planId);
+
+    if (!instance.hasTokenizationResult()) return;
 
     try {
       const payload = await handler.startPayment();
@@ -353,10 +399,8 @@ export class MGCBraintreeManager extends LitElement {
         }),
       );
     } catch (e: any) {
-      if (e?.code === 'VENMO_APP_CANCELED' || e?.code === 'VENMO_CANCELED') {
-        console.log('Venmo payment cancelled');
-      } else {
-        console.error('Venmo payment error:', e);
+      if (e?.code !== 'VENMO_APP_CANCELED' && e?.code !== 'VENMO_CANCELED') {
+        console.error('Venmo restoration error:', e);
         this.dispatchEvent(
           new CustomEvent('VenmoError', { detail: { error: e } }),
         );
@@ -422,6 +466,7 @@ export class MGCBraintreeManager extends LitElement {
       },
     );
 
+    await this.checkVenmoRestoration();
     this.dispatchEvent(new Event('BraintreeManagerSetupComplete'));
   }
 

--- a/src/form-sections/parts/braintree-manager.ts
+++ b/src/form-sections/parts/braintree-manager.ts
@@ -466,6 +466,15 @@ export class MGCBraintreeManager extends LitElement {
       },
     );
 
+    // If no Google Pay merchant ID is configured, suppress the button by
+    // returning null from the handler so payment-selector marks it unavailable.
+    if (!this.paymentConfig?.googlePayMerchantId) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (this.braintreeManager as any).paymentProviders.googlePayHandler = {
+        get: async () => null,
+      };
+    }
+
     await this.checkVenmoRestoration();
     this.dispatchEvent(new Event('BraintreeManagerSetupComplete'));
   }

--- a/src/form-sections/parts/braintree-manager.ts
+++ b/src/form-sections/parts/braintree-manager.ts
@@ -347,9 +347,10 @@ export class MGCBraintreeManager extends LitElement {
           },
         }),
       );
-    } catch (e: any) {
+    } catch (e: unknown) {
       if (this.plan?.id) this.venmoPendingStorage.clearPending(this.plan.id);
-      if (e?.code === 'VENMO_APP_CANCELED' || e?.code === 'VENMO_CANCELED') {
+      const code = (e as { code?: string })?.code;
+      if (code === 'VENMO_APP_CANCELED' || code === 'VENMO_CANCELED') {
         console.log('Venmo payment cancelled');
       } else {
         console.error('Venmo payment error:', e);
@@ -385,6 +386,9 @@ export class MGCBraintreeManager extends LitElement {
     if (!instance.hasTokenizationResult()) return;
 
     try {
+      // startPayment() re-checks hasTokenizationResult() internally and
+      // calls instance.tokenize() on the cached result — it does NOT launch
+      // a new Venmo redirect when a tokenization result is already present.
       const payload = await handler.startPayment();
       this.dispatchEvent(
         new CustomEvent('VenmoAuthorized', {
@@ -398,8 +402,9 @@ export class MGCBraintreeManager extends LitElement {
           },
         }),
       );
-    } catch (e: any) {
-      if (e?.code !== 'VENMO_APP_CANCELED' && e?.code !== 'VENMO_CANCELED') {
+    } catch (e: unknown) {
+      const code = (e as { code?: string })?.code;
+      if (code !== 'VENMO_APP_CANCELED' && code !== 'VENMO_CANCELED') {
         console.error('Venmo restoration error:', e);
         this.dispatchEvent(
           new CustomEvent('VenmoError', { detail: { error: e } }),
@@ -466,8 +471,10 @@ export class MGCBraintreeManager extends LitElement {
       },
     );
 
-    // If no Google Pay merchant ID is configured, suppress the button by
-    // returning null from the handler so payment-selector marks it unavailable.
+    // BraintreeManager (@internetarchive/donation-form) has no config option to
+    // suppress Google Pay, so we replace the handler directly. The upstream path
+    // is `BraintreeManager.paymentProviders.googlePayHandler` — if that changes
+    // this cast will silently stop working and the button may reappear.
     if (!this.paymentConfig?.googlePayMerchantId) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (this.braintreeManager as any).paymentProviders.googlePayHandler = {

--- a/src/form-sections/parts/braintree-manager.ts
+++ b/src/form-sections/parts/braintree-manager.ts
@@ -366,25 +366,25 @@ export class MGCBraintreeManager extends LitElement {
     const pending = this.venmoPendingStorage?.getPending(planId);
     if (!pending) return;
 
-    const handler =
-      await this.braintreeManager?.paymentProviders.venmoHandler.get();
-    if (!handler) {
-      this.venmoPendingStorage?.clearPending(planId);
-      return;
-    }
-
-    const instance = await handler.instance.get();
-    if (!instance) {
-      this.venmoPendingStorage?.clearPending(planId);
-      return;
-    }
-
-    // Clear before tokenizing to prevent retry loops on failure
-    this.venmoPendingStorage?.clearPending(planId);
-
-    if (!instance.hasTokenizationResult()) return;
-
     try {
+      const handler =
+        await this.braintreeManager?.paymentProviders.venmoHandler.get();
+      if (!handler) {
+        this.venmoPendingStorage?.clearPending(planId);
+        return;
+      }
+
+      const instance = await handler.instance.get();
+      if (!instance) {
+        this.venmoPendingStorage?.clearPending(planId);
+        return;
+      }
+
+      // Clear before tokenizing to prevent retry loops on failure
+      this.venmoPendingStorage?.clearPending(planId);
+
+      if (!instance.hasTokenizationResult()) return;
+
       // startPayment() re-checks hasTokenizationResult() internally and
       // calls instance.tokenize() on the cached result — it does NOT launch
       // a new Venmo redirect when a tokenization result is already present.
@@ -402,6 +402,7 @@ export class MGCBraintreeManager extends LitElement {
         }),
       );
     } catch (e: unknown) {
+      this.venmoPendingStorage?.clearPending(planId);
       const code = (e as { code?: string })?.code;
       if (code !== 'VENMO_APP_CANCELED' && code !== 'VENMO_CANCELED') {
         console.error('Venmo restoration error:', e);

--- a/src/form-sections/payment-method.ts
+++ b/src/form-sections/payment-method.ts
@@ -30,6 +30,10 @@ import type {
 import { PaymentMethodRequest } from '../models/payment-method-request';
 import { VenmoPendingStorage } from '../utils/venmo-pending-storage';
 
+// Braintree's paymentMethodType for credit card ('creditCard') differs from
+// PaymentProvider.CreditCard ('Credit Card'), so we define it explicitly here.
+const BRAINTREE_CREDITCARD_TYPE = 'creditCard' as const;
+
 /**
  * <ia-mgc-edit-payment-method>
  * - collecting the data to send to the service
@@ -166,8 +170,8 @@ export class MGCEditPaymentMethod extends LitElement {
   get paymentMethodDetail(): string {
     const { paymentMethodType, paypalEmail, venmoUsername, cardType, last4 } =
       this.plan?.payment ?? {};
-    if (paymentMethodType === 'PayPal') return paypalEmail ?? '';
-    if (paymentMethodType === 'Venmo') return venmoUsername ?? '';
+    if (paymentMethodType === PaymentProvider.PayPal) return paypalEmail ?? '';
+    if (paymentMethodType === PaymentProvider.Venmo) return venmoUsername ?? '';
     return `${cardType} - ${last4}`;
   }
 
@@ -196,7 +200,8 @@ export class MGCEditPaymentMethod extends LitElement {
                 this.clearStatusMessaging();
               }}
               ><span>
-                ${this.plan?.payment?.paymentMethodType === 'creditCard'
+                ${this.plan?.payment?.paymentMethodType ===
+                BRAINTREE_CREDITCARD_TYPE
                   ? 'Credit Card'
                   : this.plan?.payment?.paymentMethodType}:
                 ${this.paymentMethodDetail}

--- a/src/form-sections/payment-method.ts
+++ b/src/form-sections/payment-method.ts
@@ -73,8 +73,7 @@ export class MGCEditPaymentMethod extends LitElement {
 
   @property({ type: String }) updateStatus: 'success' | 'fail' | '' = '';
 
-  @property({ type: Object }) venmoPendingStorage: VenmoPendingStorage =
-    new VenmoPendingStorage();
+  @property({ type: Object }) venmoPendingStorage?: VenmoPendingStorage;
 
   createRenderRoot() {
     return this;
@@ -86,7 +85,7 @@ export class MGCEditPaymentMethod extends LitElement {
 
   private checkAndRestoreVenmoState(): void {
     if (!this.plan?.id) return;
-    if (this.venmoPendingStorage.getPending(this.plan.id)) {
+    if (this.venmoPendingStorage?.getPending(this.plan.id)) {
       this.currentlyEditing = true;
       this.selectedPaymentProvider = PaymentProvider.Venmo;
     }
@@ -280,6 +279,12 @@ export class MGCEditPaymentMethod extends LitElement {
                 id="edit-plan-payment-method-cancel"
                 class="secondary"
                 .clickHandler=${() => {
+                  if (
+                    this.selectedPaymentProvider === PaymentProvider.Venmo &&
+                    this.plan?.id
+                  ) {
+                    this.venmoPendingStorage?.clearPending(this.plan.id);
+                  }
                   this.currentlyEditing = false;
                   this.selectedPaymentProvider = '';
                   this.clearStatusMessaging();

--- a/src/form-sections/payment-method.ts
+++ b/src/form-sections/payment-method.ts
@@ -264,8 +264,15 @@ export class MGCEditPaymentMethod extends LitElement {
                   this.handleVenmoAuthorized(e);
                 }}
                 @VenmoError=${() => {
-                  this.updateStatus = 'fail';
-                  this.updateMessage = 'Venmo error, please try again';
+                  this.showVenmoError('Venmo error, please try again');
+                  // Re-dispatch with bubbles so ancestor components can react
+                  // (e.g. close a loading/redirect modal).
+                  this.dispatchEvent(
+                    new CustomEvent('VenmoError', {
+                      bubbles: true,
+                      composed: true,
+                    }),
+                  );
                 }}
               ></ia-mgc-braintree-manager>
 
@@ -345,6 +352,12 @@ export class MGCEditPaymentMethod extends LitElement {
                           button.isDisabled = false;
                           return;
                         }
+                        this.dispatchEvent(
+                          new CustomEvent('VenmoRedirectStarted', {
+                            bubbles: true,
+                            composed: true,
+                          }),
+                        );
                         await this.braintreeManagerElement?.startVenmoPayment();
                         button.isDisabled = false;
                       }}
@@ -363,6 +376,13 @@ export class MGCEditPaymentMethod extends LitElement {
           : nothing}
       </donation-form-section>
     `;
+  }
+
+  showVenmoError(
+    message: string = 'Venmo payment cancelled, please try again.',
+  ): void {
+    this.updateStatus = 'fail';
+    this.updateMessage = message;
   }
 
   private handleVenmoAuthorized(e: CustomEvent): void {

--- a/src/form-sections/payment-method.ts
+++ b/src/form-sections/payment-method.ts
@@ -247,6 +247,7 @@ export class MGCEditPaymentMethod extends LitElement {
                 .displayCreditCard=${displayCCFields}
                 .plan=${this.plan}
                 .paymentConfig=${this.paymentConfig}
+                .venmoPendingStorage=${this.venmoPendingStorage}
                 @BraintreeManagerSetupComplete=${() => {
                   this.braintreeManager =
                     this.braintreeManagerElement?.braintreeManager;
@@ -380,9 +381,13 @@ export class MGCEditPaymentMethod extends LitElement {
 
   private handlePayPalVaultAuthorized(e: CustomEvent): void {
     const { paymentMethodInfo } = e.detail;
+    const paypalEmail = paymentMethodInfo?.details?.email ?? '';
+    const donorContactInfo = this.contactFormElement?.donorContactInfo ?? {
+      customer: { email: paypalEmail },
+    };
     const newPaymentMethodRequest = new PaymentMethodRequest({
       paymentMethodInfo,
-      donorContactInfo: this.contactFormElement?.donorContactInfo ?? {},
+      donorContactInfo,
       paymentProvider: PaymentProvider.PayPal,
     });
     this.dispatchEvent(

--- a/src/form-sections/payment-method.ts
+++ b/src/form-sections/payment-method.ts
@@ -148,6 +148,14 @@ export class MGCEditPaymentMethod extends LitElement {
     return this.querySelector('ia-mgc-braintree-manager');
   }
 
+  get paymentMethodDetail(): string {
+    const { paymentMethodType, paypalEmail, venmoUsername, cardType, last4 } =
+      this.plan?.payment ?? {};
+    if (paymentMethodType === 'PayPal') return paypalEmail ?? '';
+    if (paymentMethodType === 'Venmo') return venmoUsername ?? '';
+    return `${cardType} - ${last4}`;
+  }
+
   render() {
     const displayContactForm =
       this.selectedPaymentProvider === PaymentProvider.CreditCard ||
@@ -158,7 +166,8 @@ export class MGCEditPaymentMethod extends LitElement {
 
     const displayBraintreeManager =
       this.selectedPaymentProvider === PaymentProvider.CreditCard ||
-      this.selectedPaymentProvider === PaymentProvider.PayPal;
+      this.selectedPaymentProvider === PaymentProvider.PayPal ||
+      this.selectedPaymentProvider === PaymentProvider.Venmo;
 
     return html`
       <style>
@@ -175,10 +184,7 @@ export class MGCEditPaymentMethod extends LitElement {
                 ${this.plan?.payment?.paymentMethodType === 'creditCard'
                   ? 'Credit Card'
                   : this.plan?.payment?.paymentMethodType}:
-                ${this.plan?.payment?.paymentMethodType ===
-                PaymentProvider.PayPal
-                  ? this.plan?.payment?.paypalEmail
-                  : `${this.plan?.payment?.cardType} - ${this.plan?.payment?.last4}`}
+                ${this.paymentMethodDetail}
               </span></ia-mgc-form-section-info
             >`
           : nothing}
@@ -223,6 +229,7 @@ export class MGCEditPaymentMethod extends LitElement {
               <ia-mgc-braintree-manager
                 class="${displayBraintreeManager ? '' : 'hidden'}"
                 .displayCreditCard=${displayCCFields}
+                .displayVenmo=${this.selectedPaymentProvider === PaymentProvider.Venmo}
                 .plan=${this.plan}
                 .paymentConfig=${this.paymentConfig}
                 @BraintreeManagerSetupComplete=${() => {
@@ -234,6 +241,13 @@ export class MGCEditPaymentMethod extends LitElement {
                 @PayPalVaultError=${() => {
                   this.updateStatus = 'fail';
                   this.updateMessage = 'PayPal error, please try again';
+                }}
+                @VenmoAuthorized=${(e: CustomEvent) => {
+                  this.handleVenmoAuthorized(e);
+                }}
+                @VenmoError=${() => {
+                  this.updateStatus = 'fail';
+                  this.updateMessage = 'Venmo error, please try again';
                 }}
               ></ia-mgc-braintree-manager>
 
@@ -248,7 +262,8 @@ export class MGCEditPaymentMethod extends LitElement {
                 >Cancel</ia-mgc-button
               >
               ${
-                this.selectedPaymentProvider !== PaymentProvider.PayPal
+                this.selectedPaymentProvider !== PaymentProvider.PayPal &&
+                this.selectedPaymentProvider !== PaymentProvider.Venmo
                   ? html`<ia-mgc-button
                       id="edit-plan-payment-method-submit"
                       class="primary"
@@ -306,6 +321,20 @@ export class MGCEditPaymentMethod extends LitElement {
           : nothing}
       </donation-form-section>
     `;
+  }
+
+  private handleVenmoAuthorized(e: CustomEvent): void {
+    const { paymentMethodInfo } = e.detail;
+    const newPaymentMethodRequest = new PaymentMethodRequest({
+      paymentMethodInfo,
+      donorContactInfo: this.contactFormElement?.donorContactInfo ?? {},
+      paymentProvider: PaymentProvider.Venmo,
+    });
+    this.dispatchEvent(
+      new CustomEvent('UpdatePaymentMethod', {
+        detail: { newPaymentMethodRequest },
+      }),
+    );
   }
 
   private handlePayPalVaultAuthorized(e: CustomEvent): void {

--- a/src/form-sections/payment-method.ts
+++ b/src/form-sections/payment-method.ts
@@ -28,6 +28,7 @@ import type {
   PaymentConfig,
 } from '../form-sections/parts/braintree-manager';
 import { PaymentMethodRequest } from '../models/payment-method-request';
+import { VenmoPendingStorage } from '../utils/venmo-pending-storage';
 
 /**
  * <ia-mgc-edit-payment-method>
@@ -72,8 +73,23 @@ export class MGCEditPaymentMethod extends LitElement {
 
   @property({ type: String }) updateStatus: 'success' | 'fail' | '' = '';
 
+  @property({ type: Object }) venmoPendingStorage: VenmoPendingStorage =
+    new VenmoPendingStorage();
+
   createRenderRoot() {
     return this;
+  }
+
+  override firstUpdated(): void {
+    this.checkAndRestoreVenmoState();
+  }
+
+  private checkAndRestoreVenmoState(): void {
+    if (!this.plan?.id) return;
+    if (this.venmoPendingStorage.getPending(this.plan.id)) {
+      this.currentlyEditing = true;
+      this.selectedPaymentProvider = PaymentProvider.Venmo;
+    }
   }
 
   submitPaymentMethodChange(e: Event) {
@@ -229,10 +245,11 @@ export class MGCEditPaymentMethod extends LitElement {
               <ia-mgc-braintree-manager
                 class="${displayBraintreeManager ? '' : 'hidden'}"
                 .displayCreditCard=${displayCCFields}
-                .displayVenmo=${this.selectedPaymentProvider === PaymentProvider.Venmo}
                 .plan=${this.plan}
                 .paymentConfig=${this.paymentConfig}
                 @BraintreeManagerSetupComplete=${() => {
+                  this.braintreeManager =
+                    this.braintreeManagerElement?.braintreeManager;
                   this.braintreeManagerElement?.renderPayPalVaultButton();
                 }}
                 @PayPalVaultAuthorized=${(e: CustomEvent) => {
@@ -307,6 +324,30 @@ export class MGCEditPaymentMethod extends LitElement {
                         );
                       }}
                       >Update payment method</ia-mgc-button
+                    >`
+                  : nothing
+              }
+              ${
+                this.selectedPaymentProvider === PaymentProvider.Venmo
+                  ? html`<ia-mgc-button
+                      id="edit-plan-payment-method-venmo-submit"
+                      class="primary"
+                      .clickHandler=${async (
+                        _event: Event,
+                        iaButton: MGCButton,
+                      ) => {
+                        const button = iaButton;
+                        button.isDisabled = true;
+                        const isContactFormValid =
+                          this.contactFormElement?.reportValidity();
+                        if (!isContactFormValid) {
+                          button.isDisabled = false;
+                          return;
+                        }
+                        await this.braintreeManagerElement?.startVenmoPayment();
+                        button.isDisabled = false;
+                      }}
+                      >Pay with Venmo</ia-mgc-button
                     >`
                   : nothing
               }

--- a/src/models/plan.ts
+++ b/src/models/plan.ts
@@ -11,7 +11,7 @@ export type BtData = {
     timezone: string;
     oldDate?: string; // optional for updates ISO UTC date string
   };
-  lastBillingDate: {
+  lastBillingDate?: {
     date: string | null;
     timezone_type: number;
     timezone: string;
@@ -99,13 +99,13 @@ export class MonthlyPlan {
   }
 
   get nextBillingDateLocale(): string {
-    const dateStr = this.payment?.nextBillingDate.date ?? '';
+    const dateStr = this.payment?.nextBillingDate?.date ?? '';
     if (!dateStr) return 'not found';
     return this.formatDateUTC(dateStr);
   }
 
   get lastBillingDateLocale(): string {
-    const dateStr = this.payment?.lastBillingDate.date ?? '';
+    const dateStr = this.payment?.lastBillingDate?.date ?? '';
     if (!dateStr) return '';
     return this.formatDateUTC(dateStr);
   }

--- a/src/monthly-giving-circle.ts
+++ b/src/monthly-giving-circle.ts
@@ -10,6 +10,7 @@ import {
   PaymentClientsInterface,
 } from '@internetarchive/donation-form';
 import type { IauxMgcReceipts } from './receipts';
+import { VenmoPendingStorage } from './utils/venmo-pending-storage';
 import './presentational/mgc-button';
 import type { MonthlyPlan } from './models/plan';
 import './edit-plan-form';
@@ -59,6 +60,9 @@ export class MonthlyGivingCircle extends LitElement {
     | 'editPlan' = 'welcome';
 
   @property({ type: Boolean, reflect: true }) canEdit = true;
+
+  @property({ type: Object }) venmoPendingStorage: VenmoPendingStorage =
+    new VenmoPendingStorage();
 
   @property({ type: Object }) paymentConfig: {
     referrer: string;
@@ -146,6 +150,7 @@ export class MonthlyGivingCircle extends LitElement {
             .patronEmail=${this.patronEmail}
             .plan=${this.editingThisPlan}
             .paymentConfig=${this.paymentConfig}
+            .venmoPendingStorage=${this.venmoPendingStorage}
             @cancelPlan=${() => {
               this.dispatchEvent(
                 new CustomEvent('cancelPlan', {

--- a/src/utils/venmo-pending-storage.ts
+++ b/src/utils/venmo-pending-storage.ts
@@ -1,0 +1,80 @@
+export const VENMO_MGC_PENDING_KEY_PREFIX = 'venmo_mgc_pending_';
+export const VENMO_MGC_PENDING_EXPIRY_MS = 60 * 60 * 1000; // 1 hour
+
+export type VenmoMGCPendingState = {
+  planId: string;
+  timestamp: number;
+};
+
+/**
+ * Persists a "Venmo payment in progress" flag to storage so the edit-payment
+ * flow can be resumed if Venmo redirects the user back in a new browser tab.
+ *
+ * Mirrors the class-based pattern of `VenmoRestorationStateHandler` from
+ * `iaux-donation-form` for easy porting to donation-manager.
+ *
+ * Accepts an optional `Storage` injection for unit testing.
+ */
+export class VenmoPendingStorage {
+  private storage: Storage | undefined;
+
+  constructor(storageOverride?: Storage) {
+    this.storage = storageOverride ?? this.resolveStorage();
+  }
+
+  setPending(planId: string): void {
+    const state: VenmoMGCPendingState = { planId, timestamp: Date.now() };
+    try {
+      this.storage?.setItem(
+        `${VENMO_MGC_PENDING_KEY_PREFIX}${planId}`,
+        JSON.stringify(state),
+      );
+    } catch {
+      // localStorage/sessionStorage unavailable — degrade gracefully
+    }
+  }
+
+  getPending(planId: string): VenmoMGCPendingState | null {
+    let raw: string | null = null;
+    try {
+      raw =
+        this.storage?.getItem(`${VENMO_MGC_PENDING_KEY_PREFIX}${planId}`) ??
+        null;
+    } catch {
+      return null;
+    }
+    if (!raw) return null;
+    try {
+      const state = JSON.parse(raw) as VenmoMGCPendingState;
+      if (Date.now() - state.timestamp > VENMO_MGC_PENDING_EXPIRY_MS) {
+        this.clearPending(planId);
+        return null;
+      }
+      return state;
+    } catch {
+      this.clearPending(planId);
+      return null;
+    }
+  }
+
+  clearPending(planId: string): void {
+    try {
+      this.storage?.removeItem(`${VENMO_MGC_PENDING_KEY_PREFIX}${planId}`);
+    } catch {
+      // noop
+    }
+  }
+
+  private resolveStorage(): Storage | undefined {
+    for (const s of [localStorage, sessionStorage]) {
+      try {
+        s.setItem('__venmo_test__', '1');
+        s.removeItem('__venmo_test__');
+        return s;
+      } catch {
+        // try next
+      }
+    }
+    return undefined;
+  }
+}

--- a/test/edit-plan-flow-payment-method.test.ts
+++ b/test/edit-plan-flow-payment-method.test.ts
@@ -609,3 +609,124 @@ describe('Venmo redirect restoration (firstUpdated):', () => {
     );
   });
 });
+
+describe('Venmo payment UI:', () => {
+  async function setupVenmoEditing() {
+    const plan = makePlan();
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+    await navigateToEditView(el);
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+    paymentMethodEl.currentlyEditing = true;
+    paymentMethodEl.selectedPaymentProvider = PaymentProvider.Venmo;
+    await paymentMethodEl.updateComplete;
+    return paymentMethodEl;
+  }
+
+  it('paymentMethodDetail returns venmoUsername for a Venmo plan', async () => {
+    const plan = makePlan();
+    plan.plan.btdata.paymentMethodType = 'Venmo';
+    plan.plan.btdata.venmoUsername = 'johndoe';
+
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+    await navigateToEditView(el);
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    expect(paymentMethodEl.paymentMethodDetail).to.equal('johndoe');
+  });
+
+  it('venmoSelected event sets selectedPaymentProvider to Venmo', async () => {
+    const plan = makePlan();
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+    await navigateToEditView(el);
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    paymentMethodEl.currentlyEditing = true;
+    await paymentMethodEl.updateComplete;
+
+    paymentMethodEl
+      .querySelector('payment-selector')!
+      .dispatchEvent(new Event('venmoSelected'));
+    await paymentMethodEl.updateComplete;
+
+    expect(paymentMethodEl.selectedPaymentProvider).to.equal(
+      PaymentProvider.Venmo,
+    );
+  });
+
+  it('Venmo button does not call startVenmoPayment when contact form is invalid', async () => {
+    const paymentMethodEl = await setupVenmoEditing();
+
+    (paymentMethodEl.querySelector('contact-form') as any).reportValidity =
+      () => false;
+
+    const btEl = paymentMethodEl.querySelector(
+      'ia-mgc-braintree-manager',
+    ) as MGCBraintreeManager;
+    let startVenmoCalled = false;
+    (btEl as any).startVenmoPayment = async () => {
+      startVenmoCalled = true;
+    };
+
+    const venmoBtn = paymentMethodEl.querySelector(
+      '#edit-plan-payment-method-venmo-submit',
+    ) as MGCButton;
+    venmoBtn.shadowRoot?.querySelector('button')!.click();
+    await new Promise(r => {
+      setTimeout(r, 0);
+    });
+
+    expect(startVenmoCalled).to.be.false;
+  });
+
+  it('Venmo button calls startVenmoPayment when contact form is valid', async () => {
+    const paymentMethodEl = await setupVenmoEditing();
+
+    (paymentMethodEl.querySelector('contact-form') as any).reportValidity =
+      () => true;
+
+    const btEl = paymentMethodEl.querySelector(
+      'ia-mgc-braintree-manager',
+    ) as MGCBraintreeManager;
+    let startVenmoCalled = false;
+    (btEl as any).startVenmoPayment = async () => {
+      startVenmoCalled = true;
+    };
+
+    const venmoBtn = paymentMethodEl.querySelector(
+      '#edit-plan-payment-method-venmo-submit',
+    ) as MGCButton;
+    venmoBtn.shadowRoot?.querySelector('button')!.click();
+    await new Promise(r => {
+      setTimeout(r, 50);
+    });
+
+    expect(startVenmoCalled).to.be.true;
+  });
+});

--- a/test/edit-plan-flow-payment-method.test.ts
+++ b/test/edit-plan-flow-payment-method.test.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { html, fixture, expect } from '@open-wc/testing';
+import Sinon from 'sinon';
 import { PaymentProvider } from '@internetarchive/donation-form-data-models';
 
 import type {
@@ -689,10 +690,10 @@ describe('Venmo payment UI:', () => {
     const btEl = paymentMethodEl.querySelector(
       'ia-mgc-braintree-manager',
     ) as MGCBraintreeManager;
-    let startVenmoCalled = false;
-    (btEl as any).startVenmoPayment = async () => {
-      startVenmoCalled = true;
-    };
+    const startVenmoStub = Sinon.stub(
+      btEl as any,
+      'startVenmoPayment',
+    ).resolves();
 
     const venmoBtn = paymentMethodEl.querySelector(
       '#edit-plan-payment-method-venmo-submit',
@@ -702,7 +703,8 @@ describe('Venmo payment UI:', () => {
       setTimeout(r, 0);
     });
 
-    expect(startVenmoCalled).to.be.false;
+    expect(startVenmoStub.called).to.be.false;
+    startVenmoStub.restore();
   });
 
   it('Venmo button calls startVenmoPayment when contact form is valid', async () => {
@@ -714,10 +716,10 @@ describe('Venmo payment UI:', () => {
     const btEl = paymentMethodEl.querySelector(
       'ia-mgc-braintree-manager',
     ) as MGCBraintreeManager;
-    let startVenmoCalled = false;
-    (btEl as any).startVenmoPayment = async () => {
-      startVenmoCalled = true;
-    };
+    const startVenmoStub = Sinon.stub(
+      btEl as any,
+      'startVenmoPayment',
+    ).resolves();
 
     const venmoBtn = paymentMethodEl.querySelector(
       '#edit-plan-payment-method-venmo-submit',
@@ -727,7 +729,8 @@ describe('Venmo payment UI:', () => {
       setTimeout(r, 50);
     });
 
-    expect(startVenmoCalled).to.be.true;
+    expect(startVenmoStub.calledOnce).to.be.true;
+    startVenmoStub.restore();
   });
 
   it('VenmoRedirectStarted is dispatched when Venmo button is clicked with valid contact form', async () => {
@@ -739,7 +742,10 @@ describe('Venmo payment UI:', () => {
     const btEl = paymentMethodEl.querySelector(
       'ia-mgc-braintree-manager',
     ) as MGCBraintreeManager;
-    (btEl as any).startVenmoPayment = async () => {};
+    const startVenmoStub = Sinon.stub(
+      btEl as any,
+      'startVenmoPayment',
+    ).resolves();
 
     let redirectStarted = false;
     paymentMethodEl.addEventListener('VenmoRedirectStarted', () => {
@@ -755,6 +761,7 @@ describe('Venmo payment UI:', () => {
     });
 
     expect(redirectStarted).to.be.true;
+    startVenmoStub.restore();
   });
 
   it('VenmoRedirectStarted is NOT dispatched when contact form is invalid', async () => {

--- a/test/edit-plan-flow-payment-method.test.ts
+++ b/test/edit-plan-flow-payment-method.test.ts
@@ -653,6 +653,72 @@ describe('Venmo payment UI:', () => {
     expect(paymentMethodEl.paymentMethodDetail).to.equal('johndoe');
   });
 
+  it('paymentMethodDetail returns paypalEmail for a PayPal plan', async () => {
+    const plan = makePlan();
+    plan.plan.btdata.paymentMethodType = 'PayPal';
+    plan.plan.btdata.paypalEmail = 'donor@example.com';
+
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+    await navigateToEditView(el);
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    expect(paymentMethodEl.paymentMethodDetail).to.equal('donor@example.com');
+  });
+
+  it('paymentMethodDetail returns cardType and last4 for a credit card plan', async () => {
+    const plan = makePlan();
+    plan.plan.btdata.paymentMethodType = 'creditCard';
+    plan.plan.btdata.cardType = 'Visa';
+    plan.plan.btdata.last4 = '4242';
+
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+    await navigateToEditView(el);
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    expect(paymentMethodEl.paymentMethodDetail).to.equal('Visa - 4242');
+  });
+
+  it('display label shows "Credit Card" when paymentMethodType is creditCard', async () => {
+    const plan = makePlan();
+    plan.plan.btdata.paymentMethodType = 'creditCard';
+
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+    await navigateToEditView(el);
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    const label = paymentMethodEl.querySelector(
+      'ia-mgc-form-section-info span',
+    )?.textContent;
+    expect(label).to.include('Credit Card');
+  });
+
   it('venmoSelected event sets selectedPaymentProvider to Venmo', async () => {
     const plan = makePlan();
     const el = await fixture<MonthlyGivingCircle>(

--- a/test/edit-plan-flow-payment-method.test.ts
+++ b/test/edit-plan-flow-payment-method.test.ts
@@ -729,4 +729,110 @@ describe('Venmo payment UI:', () => {
 
     expect(startVenmoCalled).to.be.true;
   });
+
+  it('VenmoRedirectStarted is dispatched when Venmo button is clicked with valid contact form', async () => {
+    const paymentMethodEl = await setupVenmoEditing();
+
+    (paymentMethodEl.querySelector('contact-form') as any).reportValidity =
+      () => true;
+
+    const btEl = paymentMethodEl.querySelector(
+      'ia-mgc-braintree-manager',
+    ) as MGCBraintreeManager;
+    (btEl as any).startVenmoPayment = async () => {};
+
+    let redirectStarted = false;
+    paymentMethodEl.addEventListener('VenmoRedirectStarted', () => {
+      redirectStarted = true;
+    });
+
+    const venmoBtn = paymentMethodEl.querySelector(
+      '#edit-plan-payment-method-venmo-submit',
+    ) as MGCButton;
+    venmoBtn.shadowRoot?.querySelector('button')!.click();
+    await new Promise(r => {
+      setTimeout(r, 50);
+    });
+
+    expect(redirectStarted).to.be.true;
+  });
+
+  it('VenmoRedirectStarted is NOT dispatched when contact form is invalid', async () => {
+    const paymentMethodEl = await setupVenmoEditing();
+
+    (paymentMethodEl.querySelector('contact-form') as any).reportValidity =
+      () => false;
+
+    let redirectStarted = false;
+    paymentMethodEl.addEventListener('VenmoRedirectStarted', () => {
+      redirectStarted = true;
+    });
+
+    const venmoBtn = paymentMethodEl.querySelector(
+      '#edit-plan-payment-method-venmo-submit',
+    ) as MGCButton;
+    venmoBtn.shadowRoot?.querySelector('button')!.click();
+    await new Promise(r => {
+      setTimeout(r, 50);
+    });
+
+    expect(redirectStarted).to.be.false;
+  });
+
+  it('showVenmoError() sets updateStatus to fail with default cancel message', async () => {
+    const paymentMethodEl = await setupVenmoEditing();
+
+    paymentMethodEl.showVenmoError();
+    await paymentMethodEl.updateComplete;
+
+    expect(paymentMethodEl.updateStatus).to.equal('fail');
+    expect(paymentMethodEl.updateMessage).to.equal(
+      'Venmo payment cancelled, please try again.',
+    );
+  });
+
+  it('showVenmoError(message) uses the provided message', async () => {
+    const paymentMethodEl = await setupVenmoEditing();
+
+    paymentMethodEl.showVenmoError('Custom Venmo error');
+    await paymentMethodEl.updateComplete;
+
+    expect(paymentMethodEl.updateStatus).to.equal('fail');
+    expect(paymentMethodEl.updateMessage).to.equal('Custom Venmo error');
+  });
+
+  it('VenmoError from braintree-manager re-dispatches with bubbles', async () => {
+    const plan = makePlan();
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+    await navigateToEditView(el);
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    paymentMethodEl.currentlyEditing = true;
+    paymentMethodEl.selectedPaymentProvider = PaymentProvider.Venmo;
+    await paymentMethodEl.updateComplete;
+
+    let bubbledVenmoError = false;
+    el.addEventListener('VenmoError', () => {
+      bubbledVenmoError = true;
+    });
+
+    paymentMethodEl.querySelector('ia-mgc-braintree-manager')!.dispatchEvent(
+      new CustomEvent('VenmoError', {
+        bubbles: true,
+        detail: { error: 'network error' },
+      }),
+    );
+    await paymentMethodEl.updateComplete;
+
+    expect(bubbledVenmoError).to.be.true;
+  });
 });

--- a/test/edit-plan-flow-payment-method.test.ts
+++ b/test/edit-plan-flow-payment-method.test.ts
@@ -13,9 +13,42 @@ import type { MGCEditPaymentMethod } from '../src/form-sections/payment-method';
 import type { MGCButton } from '../src/presentational/mgc-button';
 import type { MGCFormSectionInfo } from '../src/presentational/donation-section-info';
 import type { MGCBraintreeManager } from '../src/form-sections/parts/braintree-manager';
+import {
+  VenmoPendingStorage,
+  VENMO_MGC_PENDING_EXPIRY_MS,
+} from '../src/utils/venmo-pending-storage';
 
 import '../src/monthly-giving-circle';
 import { makePlan, navigateToEditView } from './helpers/edit-plan-helpers';
+
+/** Minimal in-memory Storage for injecting into VenmoPendingStorage */
+class MockStorage implements Storage {
+  private store: Record<string, string> = {};
+
+  get length() {
+    return Object.keys(this.store).length;
+  }
+
+  key(index: number): string | null {
+    return Object.keys(this.store)[index] ?? null;
+  }
+
+  getItem(key: string): string | null {
+    return this.store[key] ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.store[key] = value;
+  }
+
+  removeItem(key: string): void {
+    delete this.store[key];
+  }
+
+  clear(): void {
+    this.store = {};
+  }
+}
 
 describe('Payment method coordination:', () => {
   it('payment method sub-form appears when canEditPaymentMethod is true', async () => {
@@ -424,5 +457,191 @@ describe('Payment method coordination:', () => {
     // Amount and date sub-forms should be unaffected (still in default closed state)
     expect(amountEl.currentlyEditing).to.be.false;
     expect(dateEl.currentlyEditing).to.be.false;
+  });
+});
+
+describe('Venmo redirect restoration (firstUpdated):', () => {
+  it('does nothing when no pending Venmo state exists', async () => {
+    const plan = makePlan();
+    const mockStorage = new MockStorage();
+    const venmoPendingStorage = new VenmoPendingStorage(mockStorage);
+
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+        .venmoPendingStorage=${venmoPendingStorage}
+      ></ia-monthly-giving-circle>`,
+    );
+
+    await navigateToEditView(el);
+
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    expect(paymentMethodEl.currentlyEditing).to.be.false;
+    expect(paymentMethodEl.selectedPaymentProvider).to.equal('');
+  });
+
+  it('auto-opens edit form with Venmo when a valid pending key exists', async () => {
+    const plan = makePlan();
+    const mockStorage = new MockStorage();
+    const venmoPendingStorage = new VenmoPendingStorage(mockStorage);
+
+    // Pre-set a fresh pending key for this plan
+    venmoPendingStorage.setPending(plan.id);
+
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+
+    await navigateToEditView(el);
+
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    // Inject the storage with the pending key and manually trigger the check
+    paymentMethodEl.venmoPendingStorage = venmoPendingStorage;
+    // Re-run the check (simulates firstUpdated in a new tab scenario)
+    (paymentMethodEl as any).checkAndRestoreVenmoState();
+    await paymentMethodEl.updateComplete;
+
+    expect(paymentMethodEl.currentlyEditing).to.be.true;
+    expect(paymentMethodEl.selectedPaymentProvider).to.equal(
+      PaymentProvider.Venmo,
+    );
+  });
+
+  it('does not open edit form when pending key is expired', async () => {
+    const plan = makePlan();
+    const mockStorage = new MockStorage();
+    const venmoPendingStorage = new VenmoPendingStorage(mockStorage);
+
+    // Manually write an expired entry
+    mockStorage.setItem(
+      `venmo_mgc_pending_${plan.id}`,
+      JSON.stringify({
+        planId: plan.id,
+        timestamp: Date.now() - VENMO_MGC_PENDING_EXPIRY_MS - 1000,
+      }),
+    );
+
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+
+    await navigateToEditView(el);
+
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    paymentMethodEl.venmoPendingStorage = venmoPendingStorage;
+    (paymentMethodEl as any).checkAndRestoreVenmoState();
+    await paymentMethodEl.updateComplete;
+
+    expect(paymentMethodEl.currentlyEditing).to.be.false;
+  });
+
+  it('VenmoAuthorized from braintree-manager dispatches UpdatePaymentMethod with Venmo provider', async () => {
+    const plan = makePlan();
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+
+    await navigateToEditView(el);
+
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    paymentMethodEl.currentlyEditing = true;
+    paymentMethodEl.selectedPaymentProvider = PaymentProvider.Venmo;
+    await paymentMethodEl.updateComplete;
+
+    let receivedEvent: CustomEvent | null = null;
+    el.addEventListener('UpdatePaymentMethod', (e: Event) => {
+      receivedEvent = e as CustomEvent;
+    });
+
+    paymentMethodEl.querySelector('ia-mgc-braintree-manager')!.dispatchEvent(
+      new CustomEvent('VenmoAuthorized', {
+        bubbles: true,
+        detail: {
+          paymentMethodInfo: {
+            description: 'Venmo - johndoe',
+            nonce: 'nonce-venmo-test',
+            type: 'VenmoAccount',
+            details: { username: 'johndoe' },
+          },
+        },
+      }),
+    );
+    await el.updateComplete;
+
+    expect(receivedEvent).to.not.be.null;
+    const { newPaymentMethodRequest } = (
+      receivedEvent as unknown as CustomEvent
+    ).detail;
+    expect(newPaymentMethodRequest.paymentProvider).to.equal(
+      PaymentProvider.Venmo,
+    );
+    expect(newPaymentMethodRequest.paymentMethodInfo.details.username).to.equal(
+      'johndoe',
+    );
+  });
+
+  it('VenmoError from braintree-manager sets updateStatus to fail', async () => {
+    const plan = makePlan();
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+
+    await navigateToEditView(el);
+
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    paymentMethodEl.currentlyEditing = true;
+    paymentMethodEl.selectedPaymentProvider = PaymentProvider.Venmo;
+    await paymentMethodEl.updateComplete;
+
+    paymentMethodEl.querySelector('ia-mgc-braintree-manager')!.dispatchEvent(
+      new CustomEvent('VenmoError', {
+        bubbles: true,
+        detail: { error: 'network error' },
+      }),
+    );
+    await paymentMethodEl.updateComplete;
+
+    expect(paymentMethodEl.updateStatus).to.equal('fail');
+    expect(paymentMethodEl.updateMessage).to.equal(
+      'Venmo error, please try again',
+    );
   });
 });

--- a/test/edit-plan-flow-payment-method.test.ts
+++ b/test/edit-plan-flow-payment-method.test.ts
@@ -842,4 +842,163 @@ describe('Venmo payment UI:', () => {
 
     expect(bubbledVenmoError).to.be.true;
   });
+
+  it('Cancel clears pending Venmo storage when Venmo is the selected provider', async () => {
+    const plan = makePlan();
+    const mockStorage = new MockStorage();
+    const venmoPendingStorage = new VenmoPendingStorage(mockStorage);
+    venmoPendingStorage.setPending(plan.id);
+
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+        .venmoPendingStorage=${venmoPendingStorage}
+      ></ia-monthly-giving-circle>`,
+    );
+    await navigateToEditView(el);
+
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    paymentMethodEl.currentlyEditing = true;
+    paymentMethodEl.selectedPaymentProvider = PaymentProvider.Venmo;
+    await paymentMethodEl.updateComplete;
+
+    const cancelBtn = paymentMethodEl.querySelector(
+      'ia-mgc-button#edit-plan-payment-method-cancel',
+    ) as MGCButton;
+    cancelBtn.shadowRoot?.querySelector('button')!.click();
+    await paymentMethodEl.updateComplete;
+
+    expect(venmoPendingStorage.getPending(plan.id)).to.be.null;
+  });
+
+  it('Cancel does not clear storage when a non-Venmo provider is selected', async () => {
+    const plan = makePlan();
+    const mockStorage = new MockStorage();
+    const venmoPendingStorage = new VenmoPendingStorage(mockStorage);
+    venmoPendingStorage.setPending(plan.id);
+
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+        .venmoPendingStorage=${venmoPendingStorage}
+      ></ia-monthly-giving-circle>`,
+    );
+    await navigateToEditView(el);
+
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    paymentMethodEl.currentlyEditing = true;
+    paymentMethodEl.selectedPaymentProvider = PaymentProvider.CreditCard;
+    await paymentMethodEl.updateComplete;
+
+    const cancelBtn = paymentMethodEl.querySelector(
+      'ia-mgc-button#edit-plan-payment-method-cancel',
+    ) as MGCButton;
+    cancelBtn.shadowRoot?.querySelector('button')!.click();
+    await paymentMethodEl.updateComplete;
+
+    expect(venmoPendingStorage.getPending(plan.id)).to.not.be.null;
+  });
+});
+
+describe('VenmoPendingStorage single-instance ownership:', () => {
+  it('monthly-giving-circle owns the default VenmoPendingStorage instance', async () => {
+    const plan = makePlan();
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+
+    expect((el as any).venmoPendingStorage).to.be.instanceOf(
+      VenmoPendingStorage,
+    );
+  });
+
+  it('passes the same VenmoPendingStorage instance to edit-plan-form', async () => {
+    const storage = new VenmoPendingStorage(new MockStorage());
+    const plan = makePlan();
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .venmoPendingStorage=${storage}
+        .canEdit=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+
+    await navigateToEditView(el);
+
+    const editPlanForm = el.querySelector(
+      'ia-mgc-edit-plan',
+    ) as IauxEditPlanForm;
+    expect(editPlanForm.venmoPendingStorage).to.equal(storage);
+  });
+
+  it('passes the same VenmoPendingStorage instance down to payment-method', async () => {
+    const storage = new VenmoPendingStorage(new MockStorage());
+    const plan = makePlan();
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .venmoPendingStorage=${storage}
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+
+    await navigateToEditView(el);
+
+    const editPlanForm = el.querySelector(
+      'ia-mgc-edit-plan',
+    ) as IauxEditPlanForm;
+    const paymentMethodEl = editPlanForm.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+    expect(paymentMethodEl.venmoPendingStorage).to.equal(storage);
+  });
+
+  it('passes the same VenmoPendingStorage instance down to braintree-manager', async () => {
+    const storage = new VenmoPendingStorage(new MockStorage());
+    const plan = makePlan();
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .venmoPendingStorage=${storage}
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+
+    await navigateToEditView(el);
+
+    const editPlanForm = el.querySelector(
+      'ia-mgc-edit-plan',
+    ) as IauxEditPlanForm;
+    const paymentMethodEl = editPlanForm.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    // Open payment editing so braintree-manager is rendered
+    const editBtn = paymentMethodEl.querySelector(
+      'ia-mgc-form-section-info',
+    ) as MGCFormSectionInfo;
+    editBtn.dispatchEvent(new CustomEvent('editingRequested'));
+    await paymentMethodEl.updateComplete;
+
+    const btEl = paymentMethodEl.querySelector(
+      'ia-mgc-braintree-manager',
+    ) as MGCBraintreeManager;
+    expect(btEl.venmoPendingStorage).to.equal(storage);
+  });
 });

--- a/test/edit-plan-flow-payment-method.test.ts
+++ b/test/edit-plan-flow-payment-method.test.ts
@@ -20,35 +20,7 @@ import {
 
 import '../src/monthly-giving-circle';
 import { makePlan, navigateToEditView } from './helpers/edit-plan-helpers';
-
-/** Minimal in-memory Storage for injecting into VenmoPendingStorage */
-class MockStorage implements Storage {
-  private store: Record<string, string> = {};
-
-  get length() {
-    return Object.keys(this.store).length;
-  }
-
-  key(index: number): string | null {
-    return Object.keys(this.store)[index] ?? null;
-  }
-
-  getItem(key: string): string | null {
-    return this.store[key] ?? null;
-  }
-
-  setItem(key: string, value: string): void {
-    this.store[key] = value;
-  }
-
-  removeItem(key: string): void {
-    delete this.store[key];
-  }
-
-  clear(): void {
-    this.store = {};
-  }
-}
+import { MockStorage } from './helpers/mock-storage';
 
 describe('Payment method coordination:', () => {
   it('payment method sub-form appears when canEditPaymentMethod is true', async () => {
@@ -499,6 +471,7 @@ describe('Venmo redirect restoration (firstUpdated):', () => {
         .canEdit=${true}
         .canEditPaymentMethod=${true}
         .plans=${[plan]}
+        .venmoPendingStorage=${venmoPendingStorage}
       ></ia-monthly-giving-circle>`,
     );
 
@@ -508,12 +481,6 @@ describe('Venmo redirect restoration (firstUpdated):', () => {
     const paymentMethodEl = editPlan.querySelector(
       'ia-mgc-edit-payment-method',
     ) as MGCEditPaymentMethod;
-
-    // Inject the storage with the pending key and manually trigger the check
-    paymentMethodEl.venmoPendingStorage = venmoPendingStorage;
-    // Re-run the check (simulates firstUpdated in a new tab scenario)
-    (paymentMethodEl as any).checkAndRestoreVenmoState();
-    await paymentMethodEl.updateComplete;
 
     expect(paymentMethodEl.currentlyEditing).to.be.true;
     expect(paymentMethodEl.selectedPaymentProvider).to.equal(
@@ -540,6 +507,7 @@ describe('Venmo redirect restoration (firstUpdated):', () => {
         .canEdit=${true}
         .canEditPaymentMethod=${true}
         .plans=${[plan]}
+        .venmoPendingStorage=${venmoPendingStorage}
       ></ia-monthly-giving-circle>`,
     );
 
@@ -549,10 +517,6 @@ describe('Venmo redirect restoration (firstUpdated):', () => {
     const paymentMethodEl = editPlan.querySelector(
       'ia-mgc-edit-payment-method',
     ) as MGCEditPaymentMethod;
-
-    paymentMethodEl.venmoPendingStorage = venmoPendingStorage;
-    (paymentMethodEl as any).checkAndRestoreVenmoState();
-    await paymentMethodEl.updateComplete;
 
     expect(paymentMethodEl.currentlyEditing).to.be.false;
   });

--- a/test/form-sections/braintree-manager.test.ts
+++ b/test/form-sections/braintree-manager.test.ts
@@ -28,4 +28,278 @@ describe('MGCBraintreeManager', () => {
       expect(checkVenmoSpy.calledOnce).to.be.true;
     });
   });
+
+  describe('checkVenmoRestoration', () => {
+    let sandbox: Sinon.SinonSandbox;
+    let el: MGCBraintreeManager;
+    const PLAN_ID = 'test-plan-id';
+
+    function makeStorage(hasPending = true) {
+      return {
+        getPending: Sinon.stub().returns(
+          hasPending ? { planId: PLAN_ID } : null,
+        ),
+        clearPending: Sinon.stub(),
+      };
+    }
+
+    function makeBraintreeManager({
+      handlerResult = null as any,
+      handlerThrows = null as Error | null,
+    } = {}) {
+      return {
+        paymentProviders: {
+          venmoHandler: {
+            get: handlerThrows
+              ? Sinon.stub().rejects(handlerThrows)
+              : Sinon.stub().resolves(handlerResult),
+          },
+        },
+      };
+    }
+
+    function makeHandler({
+      instanceResult = null as any,
+      instanceThrows = null as Error | null,
+      startPaymentResult = null as any,
+      startPaymentThrows = null as Error | null,
+    } = {}) {
+      return {
+        instance: {
+          get: instanceThrows
+            ? Sinon.stub().rejects(instanceThrows)
+            : Sinon.stub().resolves(instanceResult),
+        },
+        startPayment: startPaymentThrows
+          ? Sinon.stub().rejects(startPaymentThrows)
+          : Sinon.stub().resolves(startPaymentResult),
+      };
+    }
+
+    function makeVenmoInstance(hasResult = true) {
+      return { hasTokenizationResult: Sinon.stub().returns(hasResult) };
+    }
+
+    beforeEach(() => {
+      sandbox = Sinon.createSandbox();
+      el = document.createElement(
+        'ia-mgc-braintree-manager',
+      ) as MGCBraintreeManager;
+      (el as any).plan = { id: PLAN_ID };
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('returns early when plan has no id', async () => {
+      (el as any).plan = {};
+      const storage = makeStorage();
+      (el as any).venmoPendingStorage = storage;
+
+      await (el as any).checkVenmoRestoration();
+
+      expect(storage.getPending.called).to.be.false;
+    });
+
+    it('returns early when no pending state exists', async () => {
+      const storage = makeStorage(false);
+      (el as any).venmoPendingStorage = storage;
+      (el as any).braintreeManager = makeBraintreeManager();
+
+      await (el as any).checkVenmoRestoration();
+
+      expect(storage.clearPending.called).to.be.false;
+    });
+
+    it('clears pending and emits no event when venmo handler is unavailable', async () => {
+      const storage = makeStorage();
+      (el as any).venmoPendingStorage = storage;
+      (el as any).braintreeManager = makeBraintreeManager({
+        handlerResult: null,
+      });
+
+      let eventFired = false;
+      el.addEventListener('VenmoAuthorized', () => {
+        eventFired = true;
+      });
+      el.addEventListener('VenmoError', () => {
+        eventFired = true;
+      });
+
+      await (el as any).checkVenmoRestoration();
+
+      expect(storage.clearPending.calledWith(PLAN_ID)).to.be.true;
+      expect(eventFired).to.be.false;
+    });
+
+    it('clears pending and emits no event when venmo instance is unavailable', async () => {
+      const storage = makeStorage();
+      (el as any).venmoPendingStorage = storage;
+      const handler = makeHandler({ instanceResult: null });
+      (el as any).braintreeManager = makeBraintreeManager({
+        handlerResult: handler,
+      });
+
+      let eventFired = false;
+      el.addEventListener('VenmoAuthorized', () => {
+        eventFired = true;
+      });
+      el.addEventListener('VenmoError', () => {
+        eventFired = true;
+      });
+
+      await (el as any).checkVenmoRestoration();
+
+      expect(storage.clearPending.calledWith(PLAN_ID)).to.be.true;
+      expect(eventFired).to.be.false;
+    });
+
+    it('clears pending and emits no event when hasTokenizationResult is false', async () => {
+      const storage = makeStorage();
+      (el as any).venmoPendingStorage = storage;
+      const instance = makeVenmoInstance(false);
+      const handler = makeHandler({ instanceResult: instance });
+      (el as any).braintreeManager = makeBraintreeManager({
+        handlerResult: handler,
+      });
+
+      let eventFired = false;
+      el.addEventListener('VenmoAuthorized', () => {
+        eventFired = true;
+      });
+      el.addEventListener('VenmoError', () => {
+        eventFired = true;
+      });
+
+      await (el as any).checkVenmoRestoration();
+
+      expect(storage.clearPending.calledWith(PLAN_ID)).to.be.true;
+      expect(eventFired).to.be.false;
+    });
+
+    it('dispatches VenmoAuthorized on successful tokenization', async () => {
+      const storage = makeStorage();
+      (el as any).venmoPendingStorage = storage;
+      const instance = makeVenmoInstance(true);
+      const payload = {
+        nonce: 'fake-nonce',
+        type: 'VenmoAccount',
+        details: { username: 'venmouser' },
+      };
+      const handler = makeHandler({
+        instanceResult: instance,
+        startPaymentResult: payload,
+      });
+      (el as any).braintreeManager = makeBraintreeManager({
+        handlerResult: handler,
+      });
+
+      let authorizedDetail: any = null;
+      el.addEventListener('VenmoAuthorized', (e: Event) => {
+        authorizedDetail = (e as CustomEvent).detail;
+      });
+
+      await (el as any).checkVenmoRestoration();
+
+      expect(authorizedDetail).to.not.be.null;
+      expect(authorizedDetail.paymentMethodInfo.nonce).to.equal('fake-nonce');
+      expect(authorizedDetail.paymentMethodInfo.details.username).to.equal(
+        'venmouser',
+      );
+    });
+
+    it('clears pending and dispatches VenmoError on unexpected error from venmoHandler.get()', async () => {
+      const storage = makeStorage();
+      (el as any).venmoPendingStorage = storage;
+      (el as any).braintreeManager = makeBraintreeManager({
+        handlerThrows: new Error('SDK unavailable'),
+      });
+
+      let errorFired = false;
+      el.addEventListener('VenmoError', () => {
+        errorFired = true;
+      });
+
+      await (el as any).checkVenmoRestoration();
+
+      expect(storage.clearPending.calledWith(PLAN_ID)).to.be.true;
+      expect(errorFired).to.be.true;
+    });
+
+    it('does not dispatch VenmoError for VENMO_APP_CANCELED', async () => {
+      const storage = makeStorage();
+      (el as any).venmoPendingStorage = storage;
+      const instance = makeVenmoInstance(true);
+      const cancelErr = Object.assign(new Error('Canceled'), {
+        code: 'VENMO_APP_CANCELED',
+      });
+      const handler = makeHandler({
+        instanceResult: instance,
+        startPaymentThrows: cancelErr,
+      });
+      (el as any).braintreeManager = makeBraintreeManager({
+        handlerResult: handler,
+      });
+
+      let errorFired = false;
+      el.addEventListener('VenmoError', () => {
+        errorFired = true;
+      });
+
+      await (el as any).checkVenmoRestoration();
+
+      expect(storage.clearPending.calledWith(PLAN_ID)).to.be.true;
+      expect(errorFired).to.be.false;
+    });
+
+    it('does not dispatch VenmoError for VENMO_CANCELED', async () => {
+      const storage = makeStorage();
+      (el as any).venmoPendingStorage = storage;
+      const instance = makeVenmoInstance(true);
+      const cancelErr = Object.assign(new Error('Canceled'), {
+        code: 'VENMO_CANCELED',
+      });
+      const handler = makeHandler({
+        instanceResult: instance,
+        startPaymentThrows: cancelErr,
+      });
+      (el as any).braintreeManager = makeBraintreeManager({
+        handlerResult: handler,
+      });
+
+      let errorFired = false;
+      el.addEventListener('VenmoError', () => {
+        errorFired = true;
+      });
+
+      await (el as any).checkVenmoRestoration();
+
+      expect(storage.clearPending.calledWith(PLAN_ID)).to.be.true;
+      expect(errorFired).to.be.false;
+    });
+
+    it('clears pending and dispatches VenmoError on unexpected startPayment error', async () => {
+      const storage = makeStorage();
+      (el as any).venmoPendingStorage = storage;
+      const instance = makeVenmoInstance(true);
+      const handler = makeHandler({
+        instanceResult: instance,
+        startPaymentThrows: new Error('Network error'),
+      });
+      (el as any).braintreeManager = makeBraintreeManager({
+        handlerResult: handler,
+      });
+
+      let errorFired = false;
+      el.addEventListener('VenmoError', () => {
+        errorFired = true;
+      });
+
+      await (el as any).checkVenmoRestoration();
+
+      expect(storage.clearPending.calledWith(PLAN_ID)).to.be.true;
+      expect(errorFired).to.be.true;
+    });
+  });
 });

--- a/test/form-sections/braintree-manager.test.ts
+++ b/test/form-sections/braintree-manager.test.ts
@@ -1,0 +1,31 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { expect } from '@open-wc/testing';
+import Sinon from 'sinon';
+
+import '../../src/form-sections/parts/braintree-manager';
+import type { MGCBraintreeManager } from '../../src/form-sections/parts/braintree-manager';
+
+describe('MGCBraintreeManager', () => {
+  describe('setupBraintreeManager', () => {
+    let sandbox: Sinon.SinonSandbox;
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('calls checkVenmoRestoration', async () => {
+      sandbox = Sinon.createSandbox();
+      const el = document.createElement(
+        'ia-mgc-braintree-manager',
+      ) as MGCBraintreeManager;
+
+      const checkVenmoSpy = sandbox
+        .stub(el as any, 'checkVenmoRestoration')
+        .resolves();
+
+      await (el as any).setupBraintreeManager();
+
+      expect(checkVenmoSpy.calledOnce).to.be.true;
+    });
+  });
+});

--- a/test/form-sections/braintree-manager.test.ts
+++ b/test/form-sections/braintree-manager.test.ts
@@ -27,6 +27,40 @@ describe('MGCBraintreeManager', () => {
 
       expect(checkVenmoSpy.calledOnce).to.be.true;
     });
+
+    it('replaces googlePayHandler with a null stub when googlePayMerchantId is absent', async () => {
+      sandbox = Sinon.createSandbox();
+      const el = document.createElement(
+        'ia-mgc-braintree-manager',
+      ) as MGCBraintreeManager;
+
+      sandbox.stub(el as any, 'checkVenmoRestoration').resolves();
+
+      // No googlePayMerchantId in paymentConfig
+      await (el as any).setupBraintreeManager();
+
+      const result =
+        await el.braintreeManager?.paymentProviders.googlePayHandler.get();
+      expect(result).to.be.null;
+    });
+
+    it('does not replace googlePayHandler when googlePayMerchantId is set', async () => {
+      sandbox = Sinon.createSandbox();
+      const el = document.createElement(
+        'ia-mgc-braintree-manager',
+      ) as MGCBraintreeManager;
+
+      (el as any).paymentConfig = { googlePayMerchantId: 'merchant-123' };
+      sandbox.stub(el as any, 'checkVenmoRestoration').resolves();
+
+      await (el as any).setupBraintreeManager();
+
+      // googlePayHandler should be the real PromisedSingleton, not our null stub
+      const handler = el.braintreeManager?.paymentProviders.googlePayHandler;
+      expect(handler).to.be.instanceOf(Object);
+      // The real handler's get() won't return null immediately (it's a PromisedSingleton)
+      expect(typeof handler?.get).to.equal('function');
+    });
   });
 
   describe('checkVenmoRestoration', () => {

--- a/test/form-sections/braintree-manager.test.ts
+++ b/test/form-sections/braintree-manager.test.ts
@@ -336,4 +336,167 @@ describe('MGCBraintreeManager', () => {
       expect(errorFired).to.be.true;
     });
   });
+
+  describe('startVenmoPayment', () => {
+    let sandbox: Sinon.SinonSandbox;
+    let el: MGCBraintreeManager;
+    const PLAN_ID = 'test-plan-id';
+
+    function makeStorage() {
+      return {
+        getPending: Sinon.stub().returns(null),
+        setPending: Sinon.stub(),
+        clearPending: Sinon.stub(),
+      };
+    }
+
+    function makeVenmoHandler({
+      startPaymentResult = null as any,
+      startPaymentThrows = null as Error | null,
+    } = {}) {
+      return {
+        startPayment: startPaymentThrows
+          ? Sinon.stub().rejects(startPaymentThrows)
+          : Sinon.stub().resolves(startPaymentResult),
+      };
+    }
+
+    function makeBraintreeManager(handler: any = null) {
+      return {
+        paymentProviders: {
+          venmoHandler: { get: Sinon.stub().resolves(handler) },
+        },
+      };
+    }
+
+    beforeEach(() => {
+      sandbox = Sinon.createSandbox();
+      el = document.createElement(
+        'ia-mgc-braintree-manager',
+      ) as MGCBraintreeManager;
+      (el as any).plan = { id: PLAN_ID };
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('returns early without setting pending when handler is unavailable', async () => {
+      const storage = makeStorage();
+      (el as any).venmoPendingStorage = storage;
+      (el as any).braintreeManager = makeBraintreeManager(null);
+
+      await el.startVenmoPayment();
+
+      expect(storage.setPending.called).to.be.false;
+      expect(storage.clearPending.called).to.be.false;
+    });
+
+    it('sets pending before payment and clears it on success', async () => {
+      const storage = makeStorage();
+      (el as any).venmoPendingStorage = storage;
+      const payload = {
+        nonce: 'fake-nonce',
+        type: 'VenmoAccount',
+        details: { username: 'venmouser' },
+      };
+      (el as any).braintreeManager = makeBraintreeManager(
+        makeVenmoHandler({ startPaymentResult: payload }),
+      );
+
+      await el.startVenmoPayment();
+
+      expect(storage.setPending.calledWith(PLAN_ID)).to.be.true;
+      expect(storage.clearPending.calledWith(PLAN_ID)).to.be.true;
+    });
+
+    it('dispatches VenmoAuthorized with correct payload on success', async () => {
+      const storage = makeStorage();
+      (el as any).venmoPendingStorage = storage;
+      const payload = {
+        nonce: 'fake-nonce',
+        type: 'VenmoAccount',
+        details: { username: 'venmouser' },
+      };
+      (el as any).braintreeManager = makeBraintreeManager(
+        makeVenmoHandler({ startPaymentResult: payload }),
+      );
+
+      let authorizedDetail: any = null;
+      el.addEventListener('VenmoAuthorized', (e: Event) => {
+        authorizedDetail = (e as CustomEvent).detail;
+      });
+
+      await el.startVenmoPayment();
+
+      expect(authorizedDetail).to.not.be.null;
+      expect(authorizedDetail.paymentMethodInfo.nonce).to.equal('fake-nonce');
+      expect(authorizedDetail.paymentMethodInfo.description).to.equal(
+        'Venmo - venmouser',
+      );
+      expect(authorizedDetail.paymentMethodInfo.details.username).to.equal(
+        'venmouser',
+      );
+    });
+
+    it('clears pending and does not dispatch VenmoError for VENMO_APP_CANCELED', async () => {
+      const storage = makeStorage();
+      (el as any).venmoPendingStorage = storage;
+      const cancelErr = Object.assign(new Error('Canceled'), {
+        code: 'VENMO_APP_CANCELED',
+      });
+      (el as any).braintreeManager = makeBraintreeManager(
+        makeVenmoHandler({ startPaymentThrows: cancelErr }),
+      );
+
+      let errorFired = false;
+      el.addEventListener('VenmoError', () => {
+        errorFired = true;
+      });
+
+      await el.startVenmoPayment();
+
+      expect(storage.clearPending.calledWith(PLAN_ID)).to.be.true;
+      expect(errorFired).to.be.false;
+    });
+
+    it('clears pending and does not dispatch VenmoError for VENMO_CANCELED', async () => {
+      const storage = makeStorage();
+      (el as any).venmoPendingStorage = storage;
+      const cancelErr = Object.assign(new Error('Canceled'), {
+        code: 'VENMO_CANCELED',
+      });
+      (el as any).braintreeManager = makeBraintreeManager(
+        makeVenmoHandler({ startPaymentThrows: cancelErr }),
+      );
+
+      let errorFired = false;
+      el.addEventListener('VenmoError', () => {
+        errorFired = true;
+      });
+
+      await el.startVenmoPayment();
+
+      expect(storage.clearPending.calledWith(PLAN_ID)).to.be.true;
+      expect(errorFired).to.be.false;
+    });
+
+    it('clears pending and dispatches VenmoError on unexpected error', async () => {
+      const storage = makeStorage();
+      (el as any).venmoPendingStorage = storage;
+      (el as any).braintreeManager = makeBraintreeManager(
+        makeVenmoHandler({ startPaymentThrows: new Error('Network error') }),
+      );
+
+      let errorFired = false;
+      el.addEventListener('VenmoError', () => {
+        errorFired = true;
+      });
+
+      await el.startVenmoPayment();
+
+      expect(storage.clearPending.calledWith(PLAN_ID)).to.be.true;
+      expect(errorFired).to.be.true;
+    });
+  });
 });

--- a/test/helpers/mock-storage.ts
+++ b/test/helpers/mock-storage.ts
@@ -1,0 +1,27 @@
+export class MockStorage implements Storage {
+  private store: Record<string, string> = {};
+
+  get length() {
+    return Object.keys(this.store).length;
+  }
+
+  key(index: number): string | null {
+    return Object.keys(this.store)[index] ?? null;
+  }
+
+  getItem(key: string): string | null {
+    return this.store[key] ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.store[key] = value;
+  }
+
+  removeItem(key: string): void {
+    delete this.store[key];
+  }
+
+  clear(): void {
+    this.store = {};
+  }
+}

--- a/test/models/plan.test.ts
+++ b/test/models/plan.test.ts
@@ -173,7 +173,7 @@ describe('MonthlyPlan', () => {
 
     it('returns empty string when lastBillingDate.date is null', () => {
       const btdata = makeBtData();
-      btdata.lastBillingDate.date = null;
+      btdata.lastBillingDate!.date = null;
       const mp = new MonthlyPlan(makePlan({ btdata }));
       expect(mp.lastBillingDateLocale).to.equal('');
     });
@@ -356,7 +356,7 @@ describe('MonthlyPlan', () => {
       expect(mp.plan.btdata.nextBillingDate.date).to.equal(
         '2024-08-15 00:00:00',
       );
-      expect(mp.plan.btdata.lastBillingDate.date).to.equal(
+      expect(mp.plan.btdata.lastBillingDate?.date).to.equal(
         '2024-07-15 00:00:00',
       );
     });

--- a/test/utils/venmo-pending-storage.test.ts
+++ b/test/utils/venmo-pending-storage.test.ts
@@ -40,6 +40,17 @@ describe('VenmoPendingStorage', () => {
       // Should not throw
       expect(() => storage.setPending(PLAN_ID)).to.not.throw();
     });
+
+    it('does not throw when setItem throws', () => {
+      const throwing = {
+        ...new MockStorage(),
+        setItem: () => {
+          throw new Error('storage full');
+        },
+      } as unknown as Storage;
+      const storage = new VenmoPendingStorage(throwing);
+      expect(() => storage.setPending(PLAN_ID)).to.not.throw();
+    });
   });
 
   describe('getPending', () => {

--- a/test/utils/venmo-pending-storage.test.ts
+++ b/test/utils/venmo-pending-storage.test.ts
@@ -1,0 +1,149 @@
+import { expect } from '@open-wc/testing';
+import {
+  VenmoPendingStorage,
+  VENMO_MGC_PENDING_KEY_PREFIX,
+  VENMO_MGC_PENDING_EXPIRY_MS,
+} from '../../src/utils/venmo-pending-storage';
+
+/** Minimal in-memory Storage implementation for testing */
+class MockStorage implements Storage {
+  private store: Record<string, string> = {};
+
+  get length() {
+    return Object.keys(this.store).length;
+  }
+
+  key(index: number): string | null {
+    return Object.keys(this.store)[index] ?? null;
+  }
+
+  getItem(key: string): string | null {
+    return this.store[key] ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.store[key] = value;
+  }
+
+  removeItem(key: string): void {
+    delete this.store[key];
+  }
+
+  clear(): void {
+    this.store = {};
+  }
+}
+
+describe('VenmoPendingStorage', () => {
+  const PLAN_ID = 'plan-token-abc123';
+  const KEY = `${VENMO_MGC_PENDING_KEY_PREFIX}${PLAN_ID}`;
+
+  describe('constructor', () => {
+    it('accepts an injected storage', () => {
+      const mock = new MockStorage();
+      const storage = new VenmoPendingStorage(mock);
+      storage.setPending(PLAN_ID);
+      expect(mock.getItem(KEY)).to.not.be.null;
+    });
+  });
+
+  describe('setPending', () => {
+    it('writes JSON with planId and a recent timestamp', () => {
+      const mock = new MockStorage();
+      const storage = new VenmoPendingStorage(mock);
+      const before = Date.now();
+      storage.setPending(PLAN_ID);
+      const after = Date.now();
+
+      const raw = mock.getItem(KEY);
+      expect(raw).to.not.be.null;
+      const parsed = JSON.parse(raw!);
+      expect(parsed.planId).to.equal(PLAN_ID);
+      expect(parsed.timestamp).to.be.at.least(before);
+      expect(parsed.timestamp).to.be.at.most(after);
+    });
+
+    it('does not throw when storage is unavailable', () => {
+      const storage = new VenmoPendingStorage(undefined);
+      // Should not throw
+      expect(() => storage.setPending(PLAN_ID)).to.not.throw();
+    });
+  });
+
+  describe('getPending', () => {
+    it('returns state when key exists and is fresh', () => {
+      const mock = new MockStorage();
+      const storage = new VenmoPendingStorage(mock);
+      storage.setPending(PLAN_ID);
+
+      const result = storage.getPending(PLAN_ID);
+      expect(result).to.not.be.null;
+      expect(result!.planId).to.equal(PLAN_ID);
+    });
+
+    it('returns null when key is absent', () => {
+      const mock = new MockStorage();
+      const storage = new VenmoPendingStorage(mock);
+
+      expect(storage.getPending(PLAN_ID)).to.be.null;
+    });
+
+    it('returns null and clears key when expired', () => {
+      const mock = new MockStorage();
+      const storage = new VenmoPendingStorage(mock);
+      const expiredState = {
+        planId: PLAN_ID,
+        timestamp: Date.now() - VENMO_MGC_PENDING_EXPIRY_MS - 1000,
+      };
+      mock.setItem(KEY, JSON.stringify(expiredState));
+
+      const result = storage.getPending(PLAN_ID);
+      expect(result).to.be.null;
+      expect(mock.getItem(KEY)).to.be.null;
+    });
+
+    it('returns null and clears key on malformed JSON', () => {
+      const mock = new MockStorage();
+      const storage = new VenmoPendingStorage(mock);
+      mock.setItem(KEY, 'not-valid-json{{{');
+
+      const result = storage.getPending(PLAN_ID);
+      expect(result).to.be.null;
+      expect(mock.getItem(KEY)).to.be.null;
+    });
+
+    it('returns null when storage getItem throws', () => {
+      const throwingStorage = {
+        ...new MockStorage(),
+        getItem: () => {
+          throw new Error('storage unavailable');
+        },
+      } as unknown as Storage;
+      const storage = new VenmoPendingStorage(throwingStorage);
+      expect(storage.getPending(PLAN_ID)).to.be.null;
+    });
+  });
+
+  describe('clearPending', () => {
+    it('removes the key from storage', () => {
+      const mock = new MockStorage();
+      const storage = new VenmoPendingStorage(mock);
+      storage.setPending(PLAN_ID);
+      expect(mock.getItem(KEY)).to.not.be.null;
+
+      storage.clearPending(PLAN_ID);
+      expect(mock.getItem(KEY)).to.be.null;
+    });
+
+    it('does not throw when key does not exist', () => {
+      const mock = new MockStorage();
+      const storage = new VenmoPendingStorage(mock);
+      expect(() => storage.clearPending(PLAN_ID)).to.not.throw();
+    });
+
+    it('does not throw when storage is unavailable', () => {
+      const storage = new VenmoPendingStorage(undefined);
+      expect(() => storage.clearPending(PLAN_ID)).to.not.throw();
+    });
+  });
+});

--- a/test/utils/venmo-pending-storage.test.ts
+++ b/test/utils/venmo-pending-storage.test.ts
@@ -4,35 +4,7 @@ import {
   VENMO_MGC_PENDING_KEY_PREFIX,
   VENMO_MGC_PENDING_EXPIRY_MS,
 } from '../../src/utils/venmo-pending-storage';
-
-/** Minimal in-memory Storage implementation for testing */
-class MockStorage implements Storage {
-  private store: Record<string, string> = {};
-
-  get length() {
-    return Object.keys(this.store).length;
-  }
-
-  key(index: number): string | null {
-    return Object.keys(this.store)[index] ?? null;
-  }
-
-  getItem(key: string): string | null {
-    return this.store[key] ?? null;
-  }
-
-  setItem(key: string, value: string): void {
-    this.store[key] = value;
-  }
-
-  removeItem(key: string): void {
-    delete this.store[key];
-  }
-
-  clear(): void {
-    this.store = {};
-  }
-}
+import { MockStorage } from '../helpers/mock-storage';
 
 describe('VenmoPendingStorage', () => {
   const PLAN_ID = 'plan-token-abc123';

--- a/test/utils/venmo-pending-storage.test.ts
+++ b/test/utils/venmo-pending-storage.test.ts
@@ -128,5 +128,17 @@ describe('VenmoPendingStorage', () => {
       const storage = new VenmoPendingStorage(undefined);
       expect(() => storage.clearPending(PLAN_ID)).to.not.throw();
     });
+
+    it('does not throw when removeItem throws', () => {
+      const mock = new MockStorage();
+      const throwing = {
+        ...mock,
+        removeItem: () => {
+          throw new Error('storage error');
+        },
+      } as unknown as Storage;
+      const storage = new VenmoPendingStorage(throwing);
+      expect(() => storage.clearPending(PLAN_ID)).to.not.throw();
+    });
   });
 });


### PR DESCRIPTION
https://internetarchive.github.io/iaux-monthly-giving-circle/pr/pr-77/demo/
 Partial QA available:
- open URL in a mobile browser, ✅  venmo button appears
- click venmo button, ✅ contact form opens
  - submit without adding contact info, ✅ contact form validates and requests all information
- add contact information, submit, ✅ opens venmo page


Demo page overrides: Venmo error & Success
- edit plan, open payment method form -> click at the top: Venmo Error - ✅ venmo error message next to the submit button
  - then, click Venmo Success -> form closes with venmo info showing. ✅ 