### PR TITLE
New payment method options: Applepay and googlepay 

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -62,6 +62,10 @@
       <input type="checkbox" id="simulate-applepay" name="simulate-applepay">
       <label for="simulate-applepay">Force show + simulate Apple Pay (for browsers without real Apple Pay support)</label>
 
+      <br>
+      <input type="checkbox" id="simulate-googlepay" name="simulate-googlepay">
+      <label for="simulate-googlepay">Force show + simulate Google Pay (for browsers/setups without real Google Pay support)</label>
+
       <p id="interaction-status-area" style="min-height: 50px;margin: 10px;"></p>
     </div>
   </div>
@@ -802,6 +806,92 @@
           applePaySimulationInterval = null;
         }
         uxMessageInfoArea.innerText = 'Apple Pay simulation disabled.';
+      }
+    });
+
+    // --- Google Pay simulation (force-show + fake handler) ---
+    // Real Google Pay availability (payment-selector.ts) depends on the
+    // Google Pay JS SDK's paymentsClient.isReadyToPay() resolving true, which
+    // in turn needs a real merchant ID and a browser/account combo Google
+    // considers eligible — never true for the placeholder merchant ID this
+    // demo uses. This installs a fake Braintree googlePayHandler so the REAL
+    // code path (payment-method.ts -> startGooglePayPayment ->
+    // handler.instance.get() -> paymentsClient.loadPaymentData ->
+    // instance.parseResponse) can be exercised end-to-end in any browser,
+    // distinct from the "Mock Google Pay success/error" buttons above (which
+    // dispatch the result event directly, skipping the real code entirely).
+    //
+    // Unlike Apple Pay, Google Pay has no browser-global session class to
+    // fake — everything is mediated through the handler object itself — so
+    // there's no window.* shim needed here.
+
+    function makeFakeGooglePayHandler() {
+      const instance = {
+        createPaymentDataRequest: (req) => req,
+        parseResponse: () => Promise.resolve({
+          nonce: `demo-fake-googlepay-nonce-${Date.now()}`,
+          type: 'AndroidPayCard',
+          details: { cardType: 'Visa', lastFour: '4242' },
+        }),
+      };
+      return {
+        isBrowserSupported: async () => true,
+        instance: { get: async () => instance },
+        paymentsClient: {
+          loadPaymentData: () => {
+            const proceed = window.confirm(
+              'Google Pay Demo\n\n' +
+              'This is a simulated Google Pay sheet — no real Google Pay session ' +
+              'exists in this browser.\n\n' +
+              'Click OK to simulate a successful payment authorization for Visa ...4242.',
+            );
+            if (!proceed) {
+              uxMessageInfoArea.innerText = 'Simulated Google Pay sheet cancelled.';
+              const err = new Error('User closed the Payment Request UI.');
+              err.statusCode = 'CANCELED';
+              return Promise.reject(err);
+            }
+            uxMessageInfoArea.innerText = 'Simulated Google Pay sheet: auto-authorizing payment...';
+            return Promise.resolve({ fakePaymentData: true });
+          },
+        },
+      };
+    }
+
+    let googlePaySimulationInterval = null;
+
+    function tickGooglePaySimulation() {
+      const bt = document.querySelector('ia-mgc-braintree-manager');
+      const braintreeManager = bt?.braintreeManager;
+      if (braintreeManager && !braintreeManager.__demoGooglePayPatched) {
+        braintreeManager.paymentProviders.googlePayHandler = {
+          get: async () => makeFakeGooglePayHandler(),
+        };
+        braintreeManager.__demoGooglePayPatched = true;
+      }
+
+      // Force the icon visible directly, in case <payment-selector> already
+      // ran its (real, negative) availability check before we got to patch
+      // the handler above.
+      const selector = document.querySelector(
+        'ia-mgc-edit-payment-method payment-selector',
+      );
+      if (selector) {
+        selector.googlePayMode = 'available';
+      }
+    }
+
+    document.getElementById('simulate-googlepay').addEventListener('change', (e) => {
+      if (e.target.checked) {
+        tickGooglePaySimulation();
+        googlePaySimulationInterval = setInterval(tickGooglePaySimulation, 300);
+        uxMessageInfoArea.innerText = 'Google Pay simulation enabled — open a plan in edit mode to see the icon.';
+      } else {
+        if (googlePaySimulationInterval) {
+          clearInterval(googlePaySimulationInterval);
+          googlePaySimulationInterval = null;
+        }
+        uxMessageInfoArea.innerText = 'Google Pay simulation disabled.';
       }
     });
   </script>

--- a/demo/index.html
+++ b/demo/index.html
@@ -49,6 +49,8 @@
       <button id="toggle-edit-payment-method">Toggle edit payment method</button>
       <button id="mock-venmo-success">Mock Venmo success</button>
       <button id="mock-venmo-error">Mock Venmo error</button>
+      <button id="mock-googlepay-success">Mock Google Pay success</button>
+      <button id="mock-googlepay-error">Mock Google Pay error</button>
 
       <br>
       <input type="checkbox" id="force-successful-requests" name="force-successful-requests">
@@ -189,6 +191,27 @@
           "expirationYear": null,
           "venmoUsername": "venmojoe"
         }
+      },
+      "51902": {
+        "token": "Acbdcdcadsfdasf.1234alphanumeric.3foobar777gigglingSoda",
+        "amount": 7.5,
+        "currency": "USD",
+        "start_date": "2024-09-10 00:00:00",
+        "is_test": true,
+        "btdata": {
+          "billingDayOfMonth": 10,
+          "nextBillingDate": {
+            "date": "2024-10-10 00:00:00.000000",
+            "timezone_type": 3,
+            "timezone": "UTC"
+          },
+          "status": "Active",
+          "paymentMethodType": "Google Pay",
+          "last4": "4242",
+          "cardType": "Visa",
+          "expirationMonth": null,
+          "expirationYear": null
+        }
       }
     };
 
@@ -273,7 +296,10 @@
     origin: '',
     braintreeAuthToken: 'sandbox_x634jsj7_7zybks4ybp63pbmd',
     venmoProfileId: '1953896702662410263',
-    googlePayMerchantId: '',
+    // Placeholder — a real Google Pay merchant ID (from IA's Google Pay/Braintree
+    // account setup) is required for the live button to appear. Leaving this empty
+    // suppresses Google Pay entirely (see braintree-manager.ts).
+    googlePayMerchantId: 'merchant-id-placeholder',
     environment: 'dev',
     paymentClients: new PaymentClients(
       new LazyLoaderService(),
@@ -431,9 +457,10 @@
       const provider = newPaymentMethodRequest?.paymentProvider;
       const isPayPal = provider === 'PayPal';
       const isVenmo = provider === 'Venmo';
+      const isGooglePay = provider === 'Google Pay';
 
-      // PayPal always succeeds in demo; Venmo always succeeds; CC is coin-flip
-      const heads = (isPayPal || isVenmo) ? true : flipCoin() === 1;
+      // PayPal, Venmo, and Google Pay always succeed in demo; CC is coin-flip
+      const heads = (isPayPal || isVenmo || isGooglePay) ? true : flipCoin() === 1;
       const successOrFail = heads ? 'success' : 'fail';
       const returnTiming = heads ? 1500 : 4000;
 
@@ -444,6 +471,8 @@
         methodLabel = `PayPal (${details?.email}, nonce: ${nonce})`;
       } else if (isVenmo) {
         methodLabel = `Venmo (@${details?.username}, nonce: ${nonce})`;
+      } else if (isGooglePay) {
+        methodLabel = `Google Pay (${details?.cardType} - ${details?.lastFour}, nonce: ${nonce})`;
       } else {
         methodLabel = 'Credit Card';
       }
@@ -539,6 +568,44 @@
         detail: { error: { code: 'VENMO_MOCK_ERROR', message: 'Mock Venmo error for demo' } },
       }));
       uxMessageInfoArea.innerText = 'Mock VenmoError event dispatched.';
+    });
+
+    // --- Google Pay mocks ---
+    // These fire the same events that startGooglePayPayment() fires on
+    // <ia-mgc-braintree-manager>, so payment-method.ts handles them identically.
+    // Real Google Pay requires Chrome + a registered merchant ID, so these mocks
+    // let the UI flow be exercised deterministically in any local dev environment.
+    // Open a plan in edit mode and select Google Pay before clicking.
+
+    document.getElementById('mock-googlepay-success').addEventListener('click', () => {
+      const bt = document.querySelector('ia-mgc-braintree-manager');
+      if (!bt) {
+        uxMessageInfoArea.innerText = 'No braintree manager found — open a plan in edit mode first.';
+        return;
+      }
+      bt.dispatchEvent(new CustomEvent('GooglePayVaultAuthorized', {
+        detail: {
+          paymentMethodInfo: {
+            description: 'Google Pay - Visa - 4242',
+            nonce: `mock-googlepay-nonce-${Date.now()}`,
+            type: 'AndroidPayCard',
+            details: { cardType: 'Visa', lastFour: '4242' },
+          },
+        },
+      }));
+      uxMessageInfoArea.innerText = 'Mock GooglePayVaultAuthorized event dispatched.';
+    });
+
+    document.getElementById('mock-googlepay-error').addEventListener('click', () => {
+      const bt = document.querySelector('ia-mgc-braintree-manager');
+      if (!bt) {
+        uxMessageInfoArea.innerText = 'No braintree manager found — open a plan in edit mode first.';
+        return;
+      }
+      bt.dispatchEvent(new CustomEvent('GooglePayError', {
+        detail: { error: { message: 'Mock Google Pay error for demo' } },
+      }));
+      uxMessageInfoArea.innerText = 'Mock GooglePayError event dispatched.';
     });
   </script>
 </body>

--- a/demo/index.html
+++ b/demo/index.html
@@ -51,10 +51,16 @@
       <button id="mock-venmo-error">Mock Venmo error</button>
       <button id="mock-googlepay-success">Mock Google Pay success</button>
       <button id="mock-googlepay-error">Mock Google Pay error</button>
+      <button id="mock-applepay-success">Mock Apple Pay success</button>
+      <button id="mock-applepay-error">Mock Apple Pay error</button>
 
       <br>
       <input type="checkbox" id="force-successful-requests" name="force-successful-requests">
       <label for="force-successful-requests">Force successful requests</label>
+
+      <br>
+      <input type="checkbox" id="simulate-applepay" name="simulate-applepay">
+      <label for="simulate-applepay">Force show + simulate Apple Pay (for browsers without real Apple Pay support)</label>
 
       <p id="interaction-status-area" style="min-height: 50px;margin: 10px;"></p>
     </div>
@@ -208,6 +214,27 @@
           "status": "Active",
           "paymentMethodType": "Google Pay",
           "last4": "4242",
+          "cardType": "Visa",
+          "expirationMonth": null,
+          "expirationYear": null
+        }
+      },
+      "62813": {
+        "token": "Acbdcdcadsfdasf.1234alphanumeric.3foobar888hummingTonic",
+        "amount": 12,
+        "currency": "USD",
+        "start_date": "2024-11-05 00:00:00",
+        "is_test": true,
+        "btdata": {
+          "billingDayOfMonth": 5,
+          "nextBillingDate": {
+            "date": "2024-12-05 00:00:00.000000",
+            "timezone_type": 3,
+            "timezone": "UTC"
+          },
+          "status": "Active",
+          "paymentMethodType": "Apple Pay",
+          "last4": "42",
           "cardType": "Visa",
           "expirationMonth": null,
           "expirationYear": null
@@ -458,9 +485,10 @@
       const isPayPal = provider === 'PayPal';
       const isVenmo = provider === 'Venmo';
       const isGooglePay = provider === 'Google Pay';
+      const isApplePay = provider === 'Apple Pay';
 
-      // PayPal, Venmo, and Google Pay always succeed in demo; CC is coin-flip
-      const heads = (isPayPal || isVenmo || isGooglePay) ? true : flipCoin() === 1;
+      // PayPal, Venmo, Google Pay, and Apple Pay always succeed in demo; CC is coin-flip
+      const heads = (isPayPal || isVenmo || isGooglePay || isApplePay) ? true : flipCoin() === 1;
       const successOrFail = heads ? 'success' : 'fail';
       const returnTiming = heads ? 1500 : 4000;
 
@@ -473,6 +501,8 @@
         methodLabel = `Venmo (@${details?.username}, nonce: ${nonce})`;
       } else if (isGooglePay) {
         methodLabel = `Google Pay (${details?.cardType} - ${details?.lastFour}, nonce: ${nonce})`;
+      } else if (isApplePay) {
+        methodLabel = `Apple Pay (${details?.cardType} - ${details?.lastTwo}, nonce: ${nonce})`;
       } else {
         methodLabel = 'Credit Card';
       }
@@ -606,6 +636,173 @@
         detail: { error: { message: 'Mock Google Pay error for demo' } },
       }));
       uxMessageInfoArea.innerText = 'Mock GooglePayError event dispatched.';
+    });
+
+    // --- Apple Pay mocks ---
+    // These fire the same events that startApplePayPayment() fires on
+    // <ia-mgc-braintree-manager>, so payment-method.ts handles them identically.
+    // Real Apple Pay requires Safari + a registered merchant domain, so these
+    // mocks let the UI flow be exercised deterministically in any local dev
+    // environment. Open a plan in edit mode and select Apple Pay before clicking.
+
+    document.getElementById('mock-applepay-success').addEventListener('click', () => {
+      const bt = document.querySelector('ia-mgc-braintree-manager');
+      if (!bt) {
+        uxMessageInfoArea.innerText = 'No braintree manager found — open a plan in edit mode first.';
+        return;
+      }
+      bt.dispatchEvent(new CustomEvent('ApplePayVaultAuthorized', {
+        detail: {
+          paymentMethodInfo: {
+            description: 'Apple Pay - Visa - 42',
+            nonce: `mock-applepay-nonce-${Date.now()}`,
+            type: 'ApplePayCard',
+            details: { cardType: 'Visa', lastTwo: '42' },
+          },
+        },
+      }));
+      uxMessageInfoArea.innerText = 'Mock ApplePayVaultAuthorized event dispatched.';
+    });
+
+    document.getElementById('mock-applepay-error').addEventListener('click', () => {
+      const bt = document.querySelector('ia-mgc-braintree-manager');
+      if (!bt) {
+        uxMessageInfoArea.innerText = 'No braintree manager found — open a plan in edit mode first.';
+        return;
+      }
+      bt.dispatchEvent(new CustomEvent('ApplePayError', {
+        detail: { error: { message: 'Mock Apple Pay error for demo' } },
+      }));
+      uxMessageInfoArea.innerText = 'Mock ApplePayError event dispatched.';
+    });
+
+    // --- Apple Pay simulation (force-show + fake ApplePaySession) ---
+    // Real browsers other than Safari never expose window.ApplePaySession, so
+    // <payment-selector> always hides the Apple Pay icon and the real
+    // startApplePayPayment() flow can never run outside Safari. This installs
+    // a fake ApplePaySession plus a fake Braintree applePayHandler so the REAL
+    // code path (payment-method.ts -> startApplePayPayment ->
+    // ApplePaySession -> tokenize) can be exercised end-to-end in any browser,
+    // distinct from the "Mock Apple Pay success/error" buttons above (which
+    // dispatch the result event directly, skipping the real code entirely).
+    //
+    // Note: this only fakes our own client-side call chain. It can't fake a
+    // real Apple merchant-validation round trip (Apple's validation endpoint
+    // only accepts validation URLs issued by a genuine Safari ApplePaySession
+    // by design), so this is for exercising our UI/wiring, not a substitute
+    // for testing in real Safari.
+
+    class FakeApplePaySession {
+      static STATUS_SUCCESS = 1;
+
+      static STATUS_FAILURE = 2;
+
+      static supportsVersion() { return true; }
+
+      static canMakePayments() { return true; }
+
+      constructor(version, paymentRequest) {
+        this.version = version;
+        this.paymentRequest = paymentRequest;
+      }
+
+      begin() {
+        const proceed = window.confirm(
+          'Apple Pay Demo\n\n' +
+          'This is a simulated Apple Pay sheet — no real Apple Pay session ' +
+          'exists in this browser.\n\n' +
+          'Click OK to simulate a successful payment authorization for Visa ...42.',
+        );
+        if (!proceed) {
+          uxMessageInfoArea.innerText = 'Simulated Apple Pay sheet cancelled.';
+          this.oncancel?.();
+          return;
+        }
+        uxMessageInfoArea.innerText = 'Simulated Apple Pay sheet: auto-validating merchant...';
+        Promise.resolve().then(() => {
+          this.onvalidatemerchant?.({ validationURL: 'https://fake.apple.example/validate' });
+        });
+      }
+
+      completeMerchantValidation() {
+        uxMessageInfoArea.innerText = 'Simulated Apple Pay: merchant validated, auto-authorizing payment...';
+        Promise.resolve().then(() => {
+          this.onpaymentauthorized?.({
+            payment: {
+              token: { fake: true },
+              billingContact: {},
+              shippingContact: { emailAddress: 'demo-donor@example.com' },
+            },
+          });
+        });
+      }
+
+      abort() {
+        uxMessageInfoArea.innerText = 'Simulated Apple Pay session aborted.';
+      }
+
+      completePayment(status) {
+        uxMessageInfoArea.innerText = status === FakeApplePaySession.STATUS_SUCCESS
+          ? 'Simulated Apple Pay: payment completed successfully.'
+          : 'Simulated Apple Pay: payment failed.';
+      }
+    }
+
+    function makeFakeApplePayHandler() {
+      const instance = {
+        createPaymentRequest: (req) => req,
+        performValidation: (_options, callback) => {
+          callback(null, { fakeMerchantSession: true });
+        },
+        tokenize: () => Promise.resolve({
+          nonce: `demo-fake-applepay-nonce-${Date.now()}`,
+          type: 'ApplePayCard',
+          details: { cardType: 'Visa', dpanLastTwo: '42' },
+        }),
+      };
+      return {
+        isAvailable: async () => true,
+        instance: { get: async () => instance },
+      };
+    }
+
+    let applePaySimulationInterval = null;
+
+    function tickApplePaySimulation() {
+      const bt = document.querySelector('ia-mgc-braintree-manager');
+      const braintreeManager = bt?.braintreeManager;
+      if (braintreeManager && !braintreeManager.__demoApplePayPatched) {
+        braintreeManager.paymentProviders.applePayHandler = {
+          get: async () => makeFakeApplePayHandler(),
+        };
+        braintreeManager.__demoApplePayPatched = true;
+      }
+
+      // Force the icon visible directly, in case <payment-selector> already
+      // ran its (real, negative) availability check before we got to patch
+      // the handler above.
+      const selector = document.querySelector(
+        'ia-mgc-edit-payment-method payment-selector',
+      );
+      if (selector) {
+        selector.applePayMode = 'available';
+      }
+    }
+
+    document.getElementById('simulate-applepay').addEventListener('change', (e) => {
+      if (e.target.checked) {
+        window.ApplePaySession = FakeApplePaySession;
+        tickApplePaySimulation();
+        applePaySimulationInterval = setInterval(tickApplePaySimulation, 300);
+        uxMessageInfoArea.innerText = 'Apple Pay simulation enabled — open a plan in edit mode to see the icon.';
+      } else {
+        delete window.ApplePaySession;
+        if (applePaySimulationInterval) {
+          clearInterval(applePaySimulationInterval);
+          applePaySimulationInterval = null;
+        }
+        uxMessageInfoArea.innerText = 'Apple Pay simulation disabled.';
+      }
     });
   </script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       "devDependencies": {
         "@open-wc/eslint-config": "^9.0.0",
         "@open-wc/testing": "^4.0.0",
+        "@types/applepayjs": "^14.0.9",
         "@types/mocha": "^10.0.6",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
@@ -1948,6 +1949,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/applepayjs": {
+      "version": "14.0.9",
+      "resolved": "https://registry.npmjs.org/@types/applepayjs/-/applepayjs-14.0.9.tgz",
+      "integrity": "sha512-xEprYbb0TEP/XIiDPbVnTYpDai8fTFpsQfVSfTd81Is2GOMUy7ie019eyX6Mz2ECxfjoUVKaiGSL577roIeHCg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/babel__code-frame": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@open-wc/eslint-config": "^9.0.0",
     "@open-wc/testing": "^4.0.0",
+    "@types/applepayjs": "^14.0.9",
     "@types/mocha": "^10.0.6",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
@@ -76,6 +77,10 @@
     "plugins": [
       "@typescript-eslint"
     ],
+    "globals": {
+      "ApplePaySession": "readonly",
+      "ApplePayJS": "readonly"
+    },
     "rules": {
       "no-console": 1,
       "no-unused-vars": "off",

--- a/src/form-sections/parts/braintree-manager.ts
+++ b/src/form-sections/parts/braintree-manager.ts
@@ -409,6 +409,101 @@ export class MGCBraintreeManager extends LitElement {
     }
   }
 
+  // In order to trigger the Apple Pay flow, you HAVE to call this from
+  // directly within the user-gesture handler that produced `originalEvent`
+  // (Safari requires this). Notice we're not actually using the event itself.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async startApplePayPayment(originalEvent: Event): Promise<void> {
+    const handler =
+      await this.braintreeManager?.paymentProviders.applePayHandler.get();
+    if (!handler) return;
+
+    try {
+      const applePayInstance = await handler.instance.get();
+      if (!applePayInstance) return;
+
+      const paymentRequest = applePayInstance.createPaymentRequest({
+        total: {
+          label: 'Internet Archive Monthly',
+          amount: `${this.plan?.amount ?? 0}`,
+        },
+        requiredBillingContactFields: ['postalAddress'],
+      });
+
+      const session = new ApplePaySession(3, paymentRequest);
+
+      session.onvalidatemerchant = (
+        event: ApplePayJS.ApplePayValidateMerchantEvent,
+      ) => {
+        applePayInstance.performValidation(
+          {
+            validationURL: event.validationURL,
+            displayName: 'Internet Archive',
+          },
+          (validationErr: unknown, validationData: unknown) => {
+            if (validationErr) {
+              console.error(
+                'Apple Pay merchant validation error:',
+                validationErr,
+              );
+              session.abort();
+              this.dispatchEvent(
+                new CustomEvent('ApplePayError', {
+                  detail: { error: validationErr },
+                }),
+              );
+              return;
+            }
+            session.completeMerchantValidation(validationData);
+          },
+        );
+      };
+
+      session.onpaymentauthorized = async (
+        event: ApplePayJS.ApplePayPaymentAuthorizedEvent,
+      ) => {
+        try {
+          const payload = await applePayInstance.tokenize({
+            token: event.payment.token,
+          });
+          session.completePayment(ApplePaySession.STATUS_SUCCESS);
+          this.dispatchEvent(
+            new CustomEvent('ApplePayVaultAuthorized', {
+              detail: {
+                paymentMethodInfo: {
+                  description: `Apple Pay - ${payload.details.cardType} - ${payload.details.dpanLastTwo}`,
+                  nonce: payload.nonce,
+                  type: payload.type,
+                  details: {
+                    cardType: payload.details.cardType,
+                    lastTwo: payload.details.dpanLastTwo,
+                  },
+                },
+              },
+            }),
+          );
+        } catch (e: unknown) {
+          session.completePayment(ApplePaySession.STATUS_FAILURE);
+          console.error('Apple Pay tokenization error:', e);
+          this.dispatchEvent(
+            new CustomEvent('ApplePayError', { detail: { error: e } }),
+          );
+        }
+      };
+
+      session.oncancel = () => {
+        console.log('Apple Pay payment cancelled');
+      };
+
+      session.begin();
+    } catch (e: unknown) {
+      console.error('Apple Pay error:', e);
+      this.dispatchEvent(
+        new CustomEvent('ApplePayError', { detail: { error: e } }),
+      );
+    }
+  }
+
   private async checkVenmoRestoration(): Promise<void> {
     const planId = this.plan?.id;
     if (!planId) return;

--- a/src/form-sections/parts/braintree-manager.ts
+++ b/src/form-sections/parts/braintree-manager.ts
@@ -360,6 +360,55 @@ export class MGCBraintreeManager extends LitElement {
     }
   }
 
+  async startGooglePayPayment(): Promise<void> {
+    const handler =
+      await this.braintreeManager?.paymentProviders.googlePayHandler.get();
+    if (!handler) return;
+
+    try {
+      const instance = await handler.instance.get();
+      if (!instance) return;
+
+      const paymentDataRequest = await instance.createPaymentDataRequest({
+        emailRequired: true,
+        transactionInfo: {
+          currencyCode: 'USD',
+          totalPriceStatus: 'FINAL',
+          totalPrice: `${this.plan?.amount ?? 0}`,
+        },
+      });
+
+      const paymentData =
+        await handler.paymentsClient.loadPaymentData(paymentDataRequest);
+      const payload = await instance.parseResponse(paymentData);
+      this.dispatchEvent(
+        new CustomEvent('GooglePayVaultAuthorized', {
+          detail: {
+            paymentMethodInfo: {
+              description: `Google Pay - ${payload.details.cardType} - ${payload.details.lastFour}`,
+              nonce: payload.nonce,
+              type: payload.type,
+              details: {
+                cardType: payload.details.cardType,
+                lastFour: payload.details.lastFour,
+              },
+            },
+          },
+        }),
+      );
+    } catch (e: unknown) {
+      const statusCode = (e as { statusCode?: string })?.statusCode;
+      if (statusCode === 'CANCELED') {
+        console.log('Google Pay payment cancelled');
+      } else {
+        console.error('Google Pay payment error:', e);
+        this.dispatchEvent(
+          new CustomEvent('GooglePayError', { detail: { error: e } }),
+        );
+      }
+    }
+  }
+
   private async checkVenmoRestoration(): Promise<void> {
     const planId = this.plan?.id;
     if (!planId) return;

--- a/src/form-sections/payment-method.ts
+++ b/src/form-sections/payment-method.ts
@@ -187,7 +187,8 @@ export class MGCEditPaymentMethod extends LitElement {
       this.selectedPaymentProvider === PaymentProvider.CreditCard ||
       this.selectedPaymentProvider === PaymentProvider.PayPal ||
       this.selectedPaymentProvider === PaymentProvider.Venmo ||
-      this.selectedPaymentProvider === PaymentProvider.GooglePay;
+      this.selectedPaymentProvider === PaymentProvider.GooglePay ||
+      this.selectedPaymentProvider === PaymentProvider.ApplePay;
 
     return html`
       <style>
@@ -224,8 +225,11 @@ export class MGCEditPaymentMethod extends LitElement {
                 @venmoSelected=${() => {
                   this.selectedPaymentProvider = PaymentProvider.Venmo;
                 }}
-                @applePaySelected=${() => {
+                @applePaySelected=${(e: CustomEvent) => {
                   this.selectedPaymentProvider = PaymentProvider.ApplePay;
+                  this.braintreeManagerElement?.startApplePayPayment(
+                    e.detail.originalEvent,
+                  );
                 }}
                 @googlePaySelected=${() => {
                   this.selectedPaymentProvider = PaymentProvider.GooglePay;
@@ -287,6 +291,13 @@ export class MGCEditPaymentMethod extends LitElement {
                   this.updateStatus = 'fail';
                   this.updateMessage = 'Google Pay error, please try again';
                 }}
+                @ApplePayVaultAuthorized=${(e: CustomEvent) => {
+                  this.handleApplePayVaultAuthorized(e);
+                }}
+                @ApplePayError=${() => {
+                  this.updateStatus = 'fail';
+                  this.updateMessage = 'Apple Pay error, please try again';
+                }}
               ></ia-mgc-braintree-manager>
 
               <ia-mgc-button
@@ -308,7 +319,8 @@ export class MGCEditPaymentMethod extends LitElement {
               ${
                 this.selectedPaymentProvider !== PaymentProvider.PayPal &&
                 this.selectedPaymentProvider !== PaymentProvider.Venmo &&
-                this.selectedPaymentProvider !== PaymentProvider.GooglePay
+                this.selectedPaymentProvider !== PaymentProvider.GooglePay &&
+                this.selectedPaymentProvider !== PaymentProvider.ApplePay
                   ? html`<ia-mgc-button
                       id="edit-plan-payment-method-submit"
                       class="primary"
@@ -425,6 +437,21 @@ export class MGCEditPaymentMethod extends LitElement {
       paymentMethodInfo,
       donorContactInfo: this.contactFormElement?.donorContactInfo ?? {},
       paymentProvider: PaymentProvider.GooglePay,
+    });
+    this.plan?.setNewPaymentMethod(newPaymentMethodRequest);
+    this.dispatchEvent(
+      new CustomEvent('UpdatePaymentMethod', {
+        detail: { newPaymentMethodRequest },
+      }),
+    );
+  }
+
+  private handleApplePayVaultAuthorized(e: CustomEvent): void {
+    const { paymentMethodInfo } = e.detail;
+    const newPaymentMethodRequest = new PaymentMethodRequest({
+      paymentMethodInfo,
+      donorContactInfo: this.contactFormElement?.donorContactInfo ?? {},
+      paymentProvider: PaymentProvider.ApplePay,
     });
     this.plan?.setNewPaymentMethod(newPaymentMethodRequest);
     this.dispatchEvent(

--- a/src/form-sections/payment-method.ts
+++ b/src/form-sections/payment-method.ts
@@ -186,7 +186,8 @@ export class MGCEditPaymentMethod extends LitElement {
     const displayBraintreeManager =
       this.selectedPaymentProvider === PaymentProvider.CreditCard ||
       this.selectedPaymentProvider === PaymentProvider.PayPal ||
-      this.selectedPaymentProvider === PaymentProvider.Venmo;
+      this.selectedPaymentProvider === PaymentProvider.Venmo ||
+      this.selectedPaymentProvider === PaymentProvider.GooglePay;
 
     return html`
       <style>
@@ -228,6 +229,7 @@ export class MGCEditPaymentMethod extends LitElement {
                 }}
                 @googlePaySelected=${() => {
                   this.selectedPaymentProvider = PaymentProvider.GooglePay;
+                  this.braintreeManagerElement?.startGooglePayPayment();
                 }}
                 @paypalSelected=${() => {
                   this.selectedPaymentProvider = PaymentProvider.PayPal;
@@ -278,6 +280,13 @@ export class MGCEditPaymentMethod extends LitElement {
                     }),
                   );
                 }}
+                @GooglePayVaultAuthorized=${(e: CustomEvent) => {
+                  this.handleGooglePayVaultAuthorized(e);
+                }}
+                @GooglePayError=${() => {
+                  this.updateStatus = 'fail';
+                  this.updateMessage = 'Google Pay error, please try again';
+                }}
               ></ia-mgc-braintree-manager>
 
               <ia-mgc-button
@@ -298,7 +307,8 @@ export class MGCEditPaymentMethod extends LitElement {
               >
               ${
                 this.selectedPaymentProvider !== PaymentProvider.PayPal &&
-                this.selectedPaymentProvider !== PaymentProvider.Venmo
+                this.selectedPaymentProvider !== PaymentProvider.Venmo &&
+                this.selectedPaymentProvider !== PaymentProvider.GooglePay
                   ? html`<ia-mgc-button
                       id="edit-plan-payment-method-submit"
                       class="primary"
@@ -402,6 +412,21 @@ export class MGCEditPaymentMethod extends LitElement {
       donorContactInfo: this.contactFormElement?.donorContactInfo ?? {},
       paymentProvider: PaymentProvider.Venmo,
     });
+    this.dispatchEvent(
+      new CustomEvent('UpdatePaymentMethod', {
+        detail: { newPaymentMethodRequest },
+      }),
+    );
+  }
+
+  private handleGooglePayVaultAuthorized(e: CustomEvent): void {
+    const { paymentMethodInfo } = e.detail;
+    const newPaymentMethodRequest = new PaymentMethodRequest({
+      paymentMethodInfo,
+      donorContactInfo: this.contactFormElement?.donorContactInfo ?? {},
+      paymentProvider: PaymentProvider.GooglePay,
+    });
+    this.plan?.setNewPaymentMethod(newPaymentMethodRequest);
     this.dispatchEvent(
       new CustomEvent('UpdatePaymentMethod', {
         detail: { newPaymentMethodRequest },

--- a/src/form-sections/payment-method.ts
+++ b/src/form-sections/payment-method.ts
@@ -1,6 +1,6 @@
 /* eslint-disable arrow-body-style */
 import { LitElement, html, nothing, css, TemplateResult } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import '@internetarchive/donation-form-section';
 import '@internetarchive/donation-form/dist/src/form-elements/contact-form/contact-form.js';
 
@@ -79,6 +79,12 @@ export class MGCEditPaymentMethod extends LitElement {
 
   @property({ type: Object }) venmoPendingStorage?: VenmoPendingStorage;
 
+  // Captured once a wallet provider (PayPal/Venmo/Apple Pay/Google Pay) fires
+  // its authorized callback. Its presence is what enables the submit button for
+  // those providers; the submit click then saves it. Credit Card doesn't use
+  // this — it validates and builds its request on submit.
+  @state() private authorizedPaymentMethodRequest?: PaymentMethodRequest;
+
   createRenderRoot() {
     return this;
   }
@@ -99,6 +105,13 @@ export class MGCEditPaymentMethod extends LitElement {
     e.preventDefault();
   }
 
+  private selectProvider(provider: string): void {
+    this.selectedPaymentProvider = provider;
+    // A previously authorized wallet nonce must not carry over to a different
+    // method, so drop it whenever the selection changes.
+    this.authorizedPaymentMethodRequest = undefined;
+  }
+
   clearStatusMessaging() {
     this.updateMessage = '';
     this.updateStatus = '';
@@ -114,6 +127,7 @@ export class MGCEditPaymentMethod extends LitElement {
     if (status === 'success') {
       this.currentlyEditing = false;
       this.selectedPaymentProvider = '';
+      this.authorizedPaymentMethodRequest = undefined;
       return;
     }
     this.updateRequestButton.isDisabled = false;
@@ -183,12 +197,14 @@ export class MGCEditPaymentMethod extends LitElement {
     const displayCCFields =
       this.selectedPaymentProvider === PaymentProvider.CreditCard;
 
-    const displayBraintreeManager =
+    const displayBraintreeManager = !!this.selectedPaymentProvider;
+
+    // Credit Card can be submitted as soon as it's selected (fields are
+    // validated on submit); the wallet providers can only be submitted once
+    // they've authorized and handed us a payment method request.
+    const submitEnabled =
       this.selectedPaymentProvider === PaymentProvider.CreditCard ||
-      this.selectedPaymentProvider === PaymentProvider.PayPal ||
-      this.selectedPaymentProvider === PaymentProvider.Venmo ||
-      this.selectedPaymentProvider === PaymentProvider.GooglePay ||
-      this.selectedPaymentProvider === PaymentProvider.ApplePay;
+      !!this.authorizedPaymentMethodRequest;
 
     return html`
       <style>
@@ -220,26 +236,26 @@ export class MGCEditPaymentMethod extends LitElement {
                   (e.target as any)?.showPaypalButton();
                 }}
                 @creditCardSelected=${() => {
-                  this.selectedPaymentProvider = PaymentProvider.CreditCard;
+                  this.selectProvider(PaymentProvider.CreditCard);
                 }}
                 @venmoSelected=${() => {
-                  this.selectedPaymentProvider = PaymentProvider.Venmo;
+                  this.selectProvider(PaymentProvider.Venmo);
                 }}
                 @applePaySelected=${(e: CustomEvent) => {
-                  this.selectedPaymentProvider = PaymentProvider.ApplePay;
+                  this.selectProvider(PaymentProvider.ApplePay);
                   this.braintreeManagerElement?.startApplePayPayment(
                     e.detail.originalEvent,
                   );
                 }}
                 @googlePaySelected=${() => {
-                  this.selectedPaymentProvider = PaymentProvider.GooglePay;
+                  this.selectProvider(PaymentProvider.GooglePay);
                   this.braintreeManagerElement?.startGooglePayPayment();
                 }}
                 @paypalSelected=${() => {
-                  this.selectedPaymentProvider = PaymentProvider.PayPal;
+                  this.selectProvider(PaymentProvider.PayPal);
                 }}
                 @resetPaymentMethod=${async () => {
-                  this.selectedPaymentProvider = '';
+                  this.selectProvider('');
                 }}
                 tabindex="0"
               >
@@ -312,61 +328,69 @@ export class MGCEditPaymentMethod extends LitElement {
                   }
                   this.currentlyEditing = false;
                   this.selectedPaymentProvider = '';
+                  this.authorizedPaymentMethodRequest = undefined;
                   this.clearStatusMessaging();
                 }}
                 >Cancel</ia-mgc-button
               >
-              ${
-                this.selectedPaymentProvider !== PaymentProvider.PayPal &&
-                this.selectedPaymentProvider !== PaymentProvider.Venmo &&
-                this.selectedPaymentProvider !== PaymentProvider.GooglePay &&
-                this.selectedPaymentProvider !== PaymentProvider.ApplePay
-                  ? html`<ia-mgc-button
-                      id="edit-plan-payment-method-submit"
-                      class="primary"
-                      type="submit"
-                      .isDisabled=${!this.selectedPaymentProvider}
-                      .clickHandler=${async (
-                        event: Event,
-                        iaButton: MGCButton,
-                      ) => {
-                        const button = iaButton;
-                        button.isDisabled = true;
-                        const isContactFormValid =
-                          this.creditCardElement?.reportValidity();
+              <ia-mgc-button
+                id="edit-plan-payment-method-submit"
+                class="primary"
+                type="submit"
+                .isDisabled=${!submitEnabled}
+                .clickHandler=${async (event: Event, iaButton: MGCButton) => {
+                  const button = iaButton;
+                  button.isDisabled = true;
 
-                        if (!isContactFormValid) {
-                          button.isDisabled = false;
-                          return;
-                        }
+                  // Wallet providers have already authorized by this point, so
+                  // submit just saves the request captured on authorization.
+                  if (
+                    this.selectedPaymentProvider !== PaymentProvider.CreditCard
+                  ) {
+                    if (!this.authorizedPaymentMethodRequest) {
+                      button.isDisabled = false;
+                      return;
+                    }
+                    this.dispatchEvent(
+                      new CustomEvent('UpdatePaymentMethod', {
+                        detail: {
+                          newPaymentMethodRequest:
+                            this.authorizedPaymentMethodRequest,
+                        },
+                      }),
+                    );
+                    return;
+                  }
 
-                        const paymentMethodInfo =
-                          (await this.braintreeManagerElement?.validateCreditCardFields()) as unknown as any;
+                  // Credit card validates its hosted fields on submit.
+                  const isContactFormValid =
+                    this.creditCardElement?.reportValidity();
+                  if (!isContactFormValid) {
+                    button.isDisabled = false;
+                    return;
+                  }
 
-                        if (!paymentMethodInfo) {
-                          button.isDisabled = false;
-                          return;
-                        }
+                  const paymentMethodInfo =
+                    (await this.braintreeManagerElement?.validateCreditCardFields()) as unknown as any;
+                  if (!paymentMethodInfo) {
+                    button.isDisabled = false;
+                    return;
+                  }
 
-                        const newPaymentMethodRequest =
-                          new PaymentMethodRequest({
-                            paymentMethodInfo,
-                            donorContactInfo:
-                              this.contactFormElement?.donorContactInfo,
-                            paymentProvider: this
-                              .selectedPaymentProvider as PaymentProvider,
-                          });
+                  const newPaymentMethodRequest = new PaymentMethodRequest({
+                    paymentMethodInfo,
+                    donorContactInfo: this.contactFormElement?.donorContactInfo,
+                    paymentProvider: PaymentProvider.CreditCard,
+                  });
 
-                        this.dispatchEvent(
-                          new CustomEvent('UpdatePaymentMethod', {
-                            detail: { newPaymentMethodRequest },
-                          }),
-                        );
-                      }}
-                      >Update payment method</ia-mgc-button
-                    >`
-                  : nothing
-              }
+                  this.dispatchEvent(
+                    new CustomEvent('UpdatePaymentMethod', {
+                      detail: { newPaymentMethodRequest },
+                    }),
+                  );
+                }}
+                >Update payment method</ia-mgc-button
+              >
               ${
                 this.selectedPaymentProvider === PaymentProvider.Venmo
                   ? html`<ia-mgc-button
@@ -419,46 +443,29 @@ export class MGCEditPaymentMethod extends LitElement {
 
   private handleVenmoAuthorized(e: CustomEvent): void {
     const { paymentMethodInfo } = e.detail;
-    const newPaymentMethodRequest = new PaymentMethodRequest({
+    this.authorizedPaymentMethodRequest = new PaymentMethodRequest({
       paymentMethodInfo,
       donorContactInfo: this.contactFormElement?.donorContactInfo ?? {},
       paymentProvider: PaymentProvider.Venmo,
     });
-    this.dispatchEvent(
-      new CustomEvent('UpdatePaymentMethod', {
-        detail: { newPaymentMethodRequest },
-      }),
-    );
   }
 
   private handleGooglePayVaultAuthorized(e: CustomEvent): void {
     const { paymentMethodInfo } = e.detail;
-    const newPaymentMethodRequest = new PaymentMethodRequest({
+    this.authorizedPaymentMethodRequest = new PaymentMethodRequest({
       paymentMethodInfo,
       donorContactInfo: this.contactFormElement?.donorContactInfo ?? {},
       paymentProvider: PaymentProvider.GooglePay,
     });
-    this.plan?.setNewPaymentMethod(newPaymentMethodRequest);
-    this.dispatchEvent(
-      new CustomEvent('UpdatePaymentMethod', {
-        detail: { newPaymentMethodRequest },
-      }),
-    );
   }
 
   private handleApplePayVaultAuthorized(e: CustomEvent): void {
     const { paymentMethodInfo } = e.detail;
-    const newPaymentMethodRequest = new PaymentMethodRequest({
+    this.authorizedPaymentMethodRequest = new PaymentMethodRequest({
       paymentMethodInfo,
       donorContactInfo: this.contactFormElement?.donorContactInfo ?? {},
       paymentProvider: PaymentProvider.ApplePay,
     });
-    this.plan?.setNewPaymentMethod(newPaymentMethodRequest);
-    this.dispatchEvent(
-      new CustomEvent('UpdatePaymentMethod', {
-        detail: { newPaymentMethodRequest },
-      }),
-    );
   }
 
   private handlePayPalVaultAuthorized(e: CustomEvent): void {
@@ -467,16 +474,11 @@ export class MGCEditPaymentMethod extends LitElement {
     const donorContactInfo = this.contactFormElement?.donorContactInfo ?? {
       customer: { email: paypalEmail },
     };
-    const newPaymentMethodRequest = new PaymentMethodRequest({
+    this.authorizedPaymentMethodRequest = new PaymentMethodRequest({
       paymentMethodInfo,
       donorContactInfo,
       paymentProvider: PaymentProvider.PayPal,
     });
-    this.dispatchEvent(
-      new CustomEvent('UpdatePaymentMethod', {
-        detail: { newPaymentMethodRequest },
-      }),
-    );
   }
 
   get styles() {

--- a/src/models/plan.ts
+++ b/src/models/plan.ts
@@ -136,6 +136,8 @@ export class MonthlyPlan {
 
     const isVenmo =
       newPaymentMethodRequest.paymentProvider === PaymentProvider.Venmo;
+    const isGooglePay =
+      newPaymentMethodRequest.paymentProvider === PaymentProvider.GooglePay;
     const paypalEmail = details.email ?? details.description ?? 'not_found';
 
     let mergedBtData: BtData;
@@ -156,6 +158,15 @@ export class MonthlyPlan {
         venmoUsername: details.username,
         cardType: null,
         last4: null,
+        expirationMonth: null,
+        expirationYear: null,
+      };
+    } else if (isGooglePay) {
+      mergedBtData = {
+        ...this.plan.btdata,
+        paymentMethodType: PaymentProvider.GooglePay,
+        cardType: details.cardType ?? null,
+        last4: details.lastFour ?? null,
         expirationMonth: null,
         expirationYear: null,
       };

--- a/src/models/plan.ts
+++ b/src/models/plan.ts
@@ -138,6 +138,8 @@ export class MonthlyPlan {
       newPaymentMethodRequest.paymentProvider === PaymentProvider.Venmo;
     const isGooglePay =
       newPaymentMethodRequest.paymentProvider === PaymentProvider.GooglePay;
+    const isApplePay =
+      newPaymentMethodRequest.paymentProvider === PaymentProvider.ApplePay;
     const paypalEmail = details.email ?? details.description ?? 'not_found';
 
     let mergedBtData: BtData;
@@ -167,6 +169,18 @@ export class MonthlyPlan {
         paymentMethodType: PaymentProvider.GooglePay,
         cardType: details.cardType ?? null,
         last4: details.lastFour ?? null,
+        expirationMonth: null,
+        expirationYear: null,
+      };
+    } else if (isApplePay) {
+      mergedBtData = {
+        ...this.plan.btdata,
+        paymentMethodType: PaymentProvider.ApplePay,
+        cardType: details.cardType ?? null,
+        // Apple Pay's tokenization payload only exposes the last two digits
+        // of the underlying card (dpanLastTwo), not the last four like every
+        // other provider here.
+        last4: details.lastTwo ?? null,
         expirationMonth: null,
         expirationYear: null,
       };

--- a/src/models/plan.ts
+++ b/src/models/plan.ts
@@ -131,66 +131,62 @@ export class MonthlyPlan {
   setNewPaymentMethod(newPaymentMethodRequest: PaymentMethodRequest): void {
     const currentPaymentMethod = this.payment;
     const { details, type } = newPaymentMethodRequest.paymentMethodInfo;
-    const isPayPal =
-      newPaymentMethodRequest.paymentProvider === PaymentProvider.PayPal;
-
-    const isVenmo =
-      newPaymentMethodRequest.paymentProvider === PaymentProvider.Venmo;
-    const isGooglePay =
-      newPaymentMethodRequest.paymentProvider === PaymentProvider.GooglePay;
-    const isApplePay =
-      newPaymentMethodRequest.paymentProvider === PaymentProvider.ApplePay;
     const paypalEmail = details.email ?? details.description ?? 'not_found';
 
     let mergedBtData: BtData;
-    if (isPayPal) {
-      mergedBtData = {
-        ...this.plan.btdata,
-        paymentMethodType: 'PayPal',
-        paypalEmail,
-        cardType: null,
-        last4: null,
-        expirationMonth: null,
-        expirationYear: null,
-      };
-    } else if (isVenmo) {
-      mergedBtData = {
-        ...this.plan.btdata,
-        paymentMethodType: PaymentProvider.Venmo,
-        venmoUsername: details.username,
-        cardType: null,
-        last4: null,
-        expirationMonth: null,
-        expirationYear: null,
-      };
-    } else if (isGooglePay) {
-      mergedBtData = {
-        ...this.plan.btdata,
-        paymentMethodType: PaymentProvider.GooglePay,
-        cardType: details.cardType ?? null,
-        last4: details.lastFour ?? null,
-        expirationMonth: null,
-        expirationYear: null,
-      };
-    } else if (isApplePay) {
-      mergedBtData = {
-        ...this.plan.btdata,
-        paymentMethodType: PaymentProvider.ApplePay,
-        cardType: details.cardType ?? null,
-        // Apple Pay's tokenization payload only exposes the last two digits
-        // of the underlying card (dpanLastTwo), not the last four like every
-        // other provider here.
-        last4: details.lastTwo ?? null,
-        expirationMonth: null,
-        expirationYear: null,
-      };
-    } else {
-      mergedBtData = {
-        ...this.plan.btdata,
-        ...details,
-        paymentMethodType: type,
-        last4: details.lastFour ?? 'unknown',
-      };
+    switch (newPaymentMethodRequest.paymentProvider) {
+      case PaymentProvider.PayPal:
+        mergedBtData = {
+          ...this.plan.btdata,
+          paymentMethodType: 'PayPal',
+          paypalEmail,
+          cardType: null,
+          last4: null,
+          expirationMonth: null,
+          expirationYear: null,
+        };
+        break;
+      case PaymentProvider.Venmo:
+        mergedBtData = {
+          ...this.plan.btdata,
+          paymentMethodType: PaymentProvider.Venmo,
+          venmoUsername: details.username,
+          cardType: null,
+          last4: null,
+          expirationMonth: null,
+          expirationYear: null,
+        };
+        break;
+      case PaymentProvider.GooglePay:
+        mergedBtData = {
+          ...this.plan.btdata,
+          paymentMethodType: PaymentProvider.GooglePay,
+          cardType: details.cardType ?? null,
+          last4: details.lastFour ?? null,
+          expirationMonth: null,
+          expirationYear: null,
+        };
+        break;
+      case PaymentProvider.ApplePay:
+        mergedBtData = {
+          ...this.plan.btdata,
+          paymentMethodType: PaymentProvider.ApplePay,
+          cardType: details.cardType ?? null,
+          // Apple Pay's tokenization payload only exposes the last two digits
+          // of the underlying card (dpanLastTwo), not the last four like every
+          // other provider here.
+          last4: details.lastTwo ?? null,
+          expirationMonth: null,
+          expirationYear: null,
+        };
+        break;
+      default:
+        mergedBtData = {
+          ...this.plan.btdata,
+          ...details,
+          paymentMethodType: type,
+          last4: details.lastFour ?? 'unknown',
+        };
     }
 
     this.plan.old_btData = currentPaymentMethod;

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -43,10 +43,8 @@ export class IauxMgcPlans extends LitElement {
                   <div class="payment-details">
                     <h3>Method</h3>
                     <p>${methodType}</p>
-                    ${plan.payment?.paymentMethodType ===
-                    PaymentProvider.CreditCard
-                      ? html`<p>${cardType}</p>
-                          <p>${last4}</p>`
+                    ${plan.payment?.cardType && plan.payment?.last4
+                      ? html`<p>${cardType} ${last4}</p>`
                       : nothing}
                     ${plan.payment?.paymentMethodType === PaymentProvider.PayPal
                       ? html`<p>
@@ -65,7 +63,9 @@ export class IauxMgcPlans extends LitElement {
                         </p>`
                       : nothing}
                     ${plan.payment?.paymentMethodType !==
-                    PaymentProvider.CreditCard
+                      PaymentProvider.CreditCard &&
+                    plan.payment?.paymentMethodType !==
+                      PaymentProvider.GooglePay
                       ? html`<p>
                           Expires:
                           ${plan.payment?.expirationMonth ??

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -62,16 +62,12 @@ export class IauxMgcPlans extends LitElement {
                           >
                         </p>`
                       : nothing}
-                    ${plan.payment?.paymentMethodType !==
-                      PaymentProvider.CreditCard &&
-                    plan.payment?.paymentMethodType !==
-                      PaymentProvider.GooglePay &&
-                    plan.payment?.paymentMethodType !== PaymentProvider.ApplePay
+                    ${plan.payment?.expirationMonth &&
+                    plan.payment?.expirationYear
                       ? html`<p>
                           Expires:
-                          ${plan.payment?.expirationMonth ??
-                          'month not found'}/${plan.payment?.expirationYear ??
-                          'year not found'}
+                          ${plan.payment.expirationMonth}/${plan.payment
+                            .expirationYear}
                         </p>`
                       : nothing}
                   </div>

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -65,7 +65,8 @@ export class IauxMgcPlans extends LitElement {
                     ${plan.payment?.paymentMethodType !==
                       PaymentProvider.CreditCard &&
                     plan.payment?.paymentMethodType !==
-                      PaymentProvider.GooglePay
+                      PaymentProvider.GooglePay &&
+                    plan.payment?.paymentMethodType !== PaymentProvider.ApplePay
                       ? html`<p>
                           Expires:
                           ${plan.payment?.expirationMonth ??

--- a/test/edit-plan-flow-payment-method.test.ts
+++ b/test/edit-plan-flow-payment-method.test.ts
@@ -14,13 +14,18 @@ import type { MGCEditPaymentMethod } from '../src/form-sections/payment-method';
 import type { MGCButton } from '../src/presentational/mgc-button';
 import type { MGCFormSectionInfo } from '../src/presentational/donation-section-info';
 import type { MGCBraintreeManager } from '../src/form-sections/parts/braintree-manager';
+import type { IauxMgcPlans } from '../src/plans';
 import {
   VenmoPendingStorage,
   VENMO_MGC_PENDING_EXPIRY_MS,
 } from '../src/utils/venmo-pending-storage';
 
 import '../src/monthly-giving-circle';
-import { makePlan, navigateToEditView } from './helpers/edit-plan-helpers';
+import {
+  makePlan,
+  navigateToEditView,
+  navigateBackToPlans,
+} from './helpers/edit-plan-helpers';
 import { MockStorage } from './helpers/mock-storage';
 
 describe('Payment method coordination:', () => {
@@ -378,6 +383,272 @@ describe('Payment method coordination:', () => {
 
     paymentMethodEl.currentlyEditing = true;
     paymentMethodEl.selectedPaymentProvider = PaymentProvider.PayPal;
+    await paymentMethodEl.updateComplete;
+
+    const submitBtn = paymentMethodEl.querySelector(
+      '#edit-plan-payment-method-submit',
+    );
+    expect(submitBtn).to.not.exist;
+  });
+
+  it('selecting Google Pay sets selectedPaymentProvider to PaymentProvider.GooglePay', async () => {
+    const plan = makePlan();
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+
+    await navigateToEditView(el);
+
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    paymentMethodEl.currentlyEditing = true;
+    await paymentMethodEl.updateComplete;
+
+    paymentMethodEl
+      .querySelector('payment-selector')!
+      .dispatchEvent(new Event('googlePaySelected', { bubbles: true }));
+    await paymentMethodEl.updateComplete;
+
+    expect(paymentMethodEl.selectedPaymentProvider).to.equal(
+      PaymentProvider.GooglePay,
+    );
+  });
+
+  it('selecting Google Pay triggers startGooglePayPayment immediately, with no confirm step', async () => {
+    const plan = makePlan();
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+
+    await navigateToEditView(el);
+
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    paymentMethodEl.currentlyEditing = true;
+    await paymentMethodEl.updateComplete;
+
+    const braintreeManagerEl = paymentMethodEl.querySelector(
+      'ia-mgc-braintree-manager',
+    ) as MGCBraintreeManager;
+
+    let startGooglePayCalled = false;
+    braintreeManagerEl.startGooglePayPayment = async () => {
+      startGooglePayCalled = true;
+    };
+
+    paymentMethodEl
+      .querySelector('payment-selector')!
+      .dispatchEvent(new Event('googlePaySelected', { bubbles: true }));
+    await paymentMethodEl.updateComplete;
+
+    expect(startGooglePayCalled).to.be.true;
+  });
+
+  it('braintree manager renders when Google Pay is the selected provider', async () => {
+    const plan = makePlan();
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+
+    await navigateToEditView(el);
+
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    paymentMethodEl.currentlyEditing = true;
+    paymentMethodEl.selectedPaymentProvider = PaymentProvider.GooglePay;
+    await paymentMethodEl.updateComplete;
+
+    const braintreeManagerEl = paymentMethodEl.querySelector(
+      'ia-mgc-braintree-manager',
+    );
+    expect(braintreeManagerEl).to.exist;
+    expect(braintreeManagerEl?.classList.contains('hidden')).to.be.false;
+  });
+
+  it('GooglePayVaultAuthorized on braintree manager dispatches UpdatePaymentMethod with Google Pay provider', async () => {
+    const plan = makePlan();
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+
+    await navigateToEditView(el);
+
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    paymentMethodEl.currentlyEditing = true;
+    paymentMethodEl.selectedPaymentProvider = PaymentProvider.GooglePay;
+    await paymentMethodEl.updateComplete;
+
+    let receivedEvent: CustomEvent | null = null;
+    el.addEventListener('UpdatePaymentMethod', (e: Event) => {
+      receivedEvent = e as CustomEvent;
+    });
+
+    paymentMethodEl.querySelector('ia-mgc-braintree-manager')!.dispatchEvent(
+      new CustomEvent('GooglePayVaultAuthorized', {
+        bubbles: true,
+        detail: {
+          paymentMethodInfo: {
+            description: 'Google Pay - Visa - 4242',
+            nonce: 'nonce-gp-test',
+            type: 'AndroidPayCard',
+            details: { cardType: 'Visa', lastFour: '4242' },
+          },
+        },
+      }),
+    );
+    await el.updateComplete;
+
+    expect(receivedEvent).to.not.be.null;
+    const { newPaymentMethodRequest } = (
+      receivedEvent as unknown as CustomEvent
+    ).detail;
+    expect(newPaymentMethodRequest.paymentProvider).to.equal(
+      PaymentProvider.GooglePay,
+    );
+    expect(newPaymentMethodRequest.paymentMethodInfo.details.cardType).to.equal(
+      'Visa',
+    );
+
+    expect(plan.payment?.paymentMethodType).to.equal(PaymentProvider.GooglePay);
+    expect(plan.payment?.cardType).to.equal('Visa');
+    expect(plan.payment?.last4).to.equal('4242');
+  });
+
+  it('GooglePayVaultAuthorized updates the plan model immediately, before any host-level UpdatePaymentMethod handling', async () => {
+    const plan = makePlan();
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+
+    await navigateToEditView(el);
+
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    paymentMethodEl.currentlyEditing = true;
+    paymentMethodEl.selectedPaymentProvider = PaymentProvider.GooglePay;
+    await paymentMethodEl.updateComplete;
+
+    // No listener for UpdatePaymentMethod / updateReceived here — proving the
+    // model update doesn't depend on the host's async round-trip.
+    paymentMethodEl.querySelector('ia-mgc-braintree-manager')!.dispatchEvent(
+      new CustomEvent('GooglePayVaultAuthorized', {
+        bubbles: true,
+        detail: {
+          paymentMethodInfo: {
+            description: 'Google Pay - Mastercard - 9999',
+            nonce: 'nonce-gp-immediate',
+            type: 'AndroidPayCard',
+            details: { cardType: 'Mastercard', lastFour: '9999' },
+          },
+        },
+      }),
+    );
+
+    expect(plan.payment?.paymentMethodType).to.equal(PaymentProvider.GooglePay);
+    expect(plan.payment?.cardType).to.equal('Mastercard');
+    expect(plan.payment?.last4).to.equal('9999');
+    expect(plan.payment?.expirationMonth).to.be.null;
+    expect(plan.payment?.expirationYear).to.be.null;
+
+    await navigateBackToPlans(el);
+
+    const mgcPlans = el.querySelector('ia-mgc-plans') as IauxMgcPlans;
+    await mgcPlans.updateComplete;
+    const detailsText =
+      mgcPlans.shadowRoot?.querySelector('.payment-details')?.textContent ?? '';
+    expect(detailsText).to.include('Mastercard');
+    expect(detailsText).to.include('...9999');
+    expect(detailsText).to.not.include('Expires');
+    expect(detailsText).to.not.include('not found');
+  });
+
+  it('GooglePayError on braintree manager sets updateStatus to fail', async () => {
+    const plan = makePlan();
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+
+    await navigateToEditView(el);
+
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    paymentMethodEl.currentlyEditing = true;
+    paymentMethodEl.selectedPaymentProvider = PaymentProvider.GooglePay;
+    await paymentMethodEl.updateComplete;
+
+    paymentMethodEl.querySelector('ia-mgc-braintree-manager')!.dispatchEvent(
+      new CustomEvent('GooglePayError', {
+        bubbles: true,
+        detail: { error: 'timeout' },
+      }),
+    );
+    await paymentMethodEl.updateComplete;
+
+    expect(paymentMethodEl.updateStatus).to.equal('fail');
+  });
+
+  it('submit button is hidden when Google Pay is the selected provider', async () => {
+    const plan = makePlan();
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+
+    await navigateToEditView(el);
+
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    paymentMethodEl.currentlyEditing = true;
+    paymentMethodEl.selectedPaymentProvider = PaymentProvider.GooglePay;
     await paymentMethodEl.updateComplete;
 
     const submitBtn = paymentMethodEl.querySelector(

--- a/test/edit-plan-flow-payment-method.test.ts
+++ b/test/edit-plan-flow-payment-method.test.ts
@@ -657,6 +657,279 @@ describe('Payment method coordination:', () => {
     expect(submitBtn).to.not.exist;
   });
 
+  it('selecting Apple Pay sets selectedPaymentProvider to PaymentProvider.ApplePay', async () => {
+    const plan = makePlan();
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+
+    await navigateToEditView(el);
+
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    paymentMethodEl.currentlyEditing = true;
+    await paymentMethodEl.updateComplete;
+
+    paymentMethodEl.querySelector('payment-selector')!.dispatchEvent(
+      new CustomEvent('applePaySelected', {
+        bubbles: true,
+        detail: { originalEvent: new Event('click') },
+      }),
+    );
+    await paymentMethodEl.updateComplete;
+
+    expect(paymentMethodEl.selectedPaymentProvider).to.equal(
+      PaymentProvider.ApplePay,
+    );
+  });
+
+  it('selecting Apple Pay triggers startApplePayPayment immediately with the forwarded click event', async () => {
+    const plan = makePlan();
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+
+    await navigateToEditView(el);
+
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    paymentMethodEl.currentlyEditing = true;
+    await paymentMethodEl.updateComplete;
+
+    const braintreeManagerEl = paymentMethodEl.querySelector(
+      'ia-mgc-braintree-manager',
+    ) as MGCBraintreeManager;
+
+    let receivedEvent: Event | undefined;
+    braintreeManagerEl.startApplePayPayment = async (originalEvent: Event) => {
+      receivedEvent = originalEvent;
+    };
+
+    const clickEvent = new Event('click');
+    paymentMethodEl.querySelector('payment-selector')!.dispatchEvent(
+      new CustomEvent('applePaySelected', {
+        bubbles: true,
+        detail: { originalEvent: clickEvent },
+      }),
+    );
+    await paymentMethodEl.updateComplete;
+
+    expect(receivedEvent).to.equal(clickEvent);
+  });
+
+  it('braintree manager renders when Apple Pay is the selected provider', async () => {
+    const plan = makePlan();
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+
+    await navigateToEditView(el);
+
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    paymentMethodEl.currentlyEditing = true;
+    paymentMethodEl.selectedPaymentProvider = PaymentProvider.ApplePay;
+    await paymentMethodEl.updateComplete;
+
+    const braintreeManagerEl = paymentMethodEl.querySelector(
+      'ia-mgc-braintree-manager',
+    );
+    expect(braintreeManagerEl).to.exist;
+    expect(braintreeManagerEl?.classList.contains('hidden')).to.be.false;
+  });
+
+  it('ApplePayVaultAuthorized on braintree manager dispatches UpdatePaymentMethod with Apple Pay provider', async () => {
+    const plan = makePlan();
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+
+    await navigateToEditView(el);
+
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    paymentMethodEl.currentlyEditing = true;
+    paymentMethodEl.selectedPaymentProvider = PaymentProvider.ApplePay;
+    await paymentMethodEl.updateComplete;
+
+    let receivedEvent: CustomEvent | null = null;
+    el.addEventListener('UpdatePaymentMethod', (e: Event) => {
+      receivedEvent = e as CustomEvent;
+    });
+
+    paymentMethodEl.querySelector('ia-mgc-braintree-manager')!.dispatchEvent(
+      new CustomEvent('ApplePayVaultAuthorized', {
+        bubbles: true,
+        detail: {
+          paymentMethodInfo: {
+            description: 'Apple Pay - Visa - 42',
+            nonce: 'nonce-ap-test',
+            type: 'ApplePayCard',
+            details: { cardType: 'Visa', lastTwo: '42' },
+          },
+        },
+      }),
+    );
+    await el.updateComplete;
+
+    expect(receivedEvent).to.not.be.null;
+    const { newPaymentMethodRequest } = (
+      receivedEvent as unknown as CustomEvent
+    ).detail;
+    expect(newPaymentMethodRequest.paymentProvider).to.equal(
+      PaymentProvider.ApplePay,
+    );
+    expect(newPaymentMethodRequest.paymentMethodInfo.details.cardType).to.equal(
+      'Visa',
+    );
+
+    expect(plan.payment?.paymentMethodType).to.equal(PaymentProvider.ApplePay);
+    expect(plan.payment?.cardType).to.equal('Visa');
+    expect(plan.payment?.last4).to.equal('42');
+  });
+
+  it('ApplePayVaultAuthorized updates the plan model immediately, before any host-level UpdatePaymentMethod handling', async () => {
+    const plan = makePlan();
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+
+    await navigateToEditView(el);
+
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    paymentMethodEl.currentlyEditing = true;
+    paymentMethodEl.selectedPaymentProvider = PaymentProvider.ApplePay;
+    await paymentMethodEl.updateComplete;
+
+    // No listener for UpdatePaymentMethod / updateReceived here — proving the
+    // model update doesn't depend on the host's async round-trip.
+    paymentMethodEl.querySelector('ia-mgc-braintree-manager')!.dispatchEvent(
+      new CustomEvent('ApplePayVaultAuthorized', {
+        bubbles: true,
+        detail: {
+          paymentMethodInfo: {
+            description: 'Apple Pay - Mastercard - 99',
+            nonce: 'nonce-ap-immediate',
+            type: 'ApplePayCard',
+            details: { cardType: 'Mastercard', lastTwo: '99' },
+          },
+        },
+      }),
+    );
+
+    expect(plan.payment?.paymentMethodType).to.equal(PaymentProvider.ApplePay);
+    expect(plan.payment?.cardType).to.equal('Mastercard');
+    expect(plan.payment?.last4).to.equal('99');
+    expect(plan.payment?.expirationMonth).to.be.null;
+    expect(plan.payment?.expirationYear).to.be.null;
+
+    await navigateBackToPlans(el);
+
+    const mgcPlans = el.querySelector('ia-mgc-plans') as IauxMgcPlans;
+    await mgcPlans.updateComplete;
+    const detailsText =
+      mgcPlans.shadowRoot?.querySelector('.payment-details')?.textContent ?? '';
+    expect(detailsText).to.include('Mastercard');
+    expect(detailsText).to.include('...99');
+    expect(detailsText).to.not.include('Expires');
+    expect(detailsText).to.not.include('not found');
+  });
+
+  it('ApplePayError on braintree manager sets updateStatus to fail', async () => {
+    const plan = makePlan();
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+
+    await navigateToEditView(el);
+
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    paymentMethodEl.currentlyEditing = true;
+    paymentMethodEl.selectedPaymentProvider = PaymentProvider.ApplePay;
+    await paymentMethodEl.updateComplete;
+
+    paymentMethodEl.querySelector('ia-mgc-braintree-manager')!.dispatchEvent(
+      new CustomEvent('ApplePayError', {
+        bubbles: true,
+        detail: { error: 'timeout' },
+      }),
+    );
+    await paymentMethodEl.updateComplete;
+
+    expect(paymentMethodEl.updateStatus).to.equal('fail');
+  });
+
+  it('submit button is hidden when Apple Pay is the selected provider', async () => {
+    const plan = makePlan();
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+
+    await navigateToEditView(el);
+
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    paymentMethodEl.currentlyEditing = true;
+    paymentMethodEl.selectedPaymentProvider = PaymentProvider.ApplePay;
+    await paymentMethodEl.updateComplete;
+
+    const submitBtn = paymentMethodEl.querySelector(
+      '#edit-plan-payment-method-submit',
+    );
+    expect(submitBtn).to.not.exist;
+  });
+
   it('updateReceived with paymentMethodUpdate success closes payment method form', async () => {
     const plan = makePlan();
     const el = await fixture<MonthlyGivingCircle>(

--- a/test/edit-plan-flow-payment-method.test.ts
+++ b/test/edit-plan-flow-payment-method.test.ts
@@ -14,18 +14,13 @@ import type { MGCEditPaymentMethod } from '../src/form-sections/payment-method';
 import type { MGCButton } from '../src/presentational/mgc-button';
 import type { MGCFormSectionInfo } from '../src/presentational/donation-section-info';
 import type { MGCBraintreeManager } from '../src/form-sections/parts/braintree-manager';
-import type { IauxMgcPlans } from '../src/plans';
 import {
   VenmoPendingStorage,
   VENMO_MGC_PENDING_EXPIRY_MS,
 } from '../src/utils/venmo-pending-storage';
 
 import '../src/monthly-giving-circle';
-import {
-  makePlan,
-  navigateToEditView,
-  navigateBackToPlans,
-} from './helpers/edit-plan-helpers';
+import { makePlan, navigateToEditView } from './helpers/edit-plan-helpers';
 import { MockStorage } from './helpers/mock-storage';
 
 describe('Payment method coordination:', () => {
@@ -279,7 +274,7 @@ describe('Payment method coordination:', () => {
     expect(renderPayPalCalled).to.be.true;
   });
 
-  it('PayPalVaultAuthorized on braintree manager dispatches UpdatePaymentMethod with PayPal provider', async () => {
+  it('PayPalVaultAuthorized enables submit; submitting dispatches UpdatePaymentMethod with PayPal provider', async () => {
     const plan = makePlan();
     const el = await fixture<MonthlyGivingCircle>(
       html`<ia-monthly-giving-circle
@@ -318,6 +313,16 @@ describe('Payment method coordination:', () => {
         },
       }),
     );
+    await paymentMethodEl.updateComplete;
+
+    // Authorization alone does not save — it just enables submit.
+    expect(receivedEvent).to.be.null;
+    const submitBtn = paymentMethodEl.querySelector(
+      '#edit-plan-payment-method-submit',
+    ) as MGCButton;
+    expect(submitBtn.isDisabled).to.not.be.true;
+
+    submitBtn.shadowRoot?.querySelector('button')!.click();
     await el.updateComplete;
 
     expect(receivedEvent).to.not.be.null;
@@ -364,7 +369,7 @@ describe('Payment method coordination:', () => {
     expect(paymentMethodEl.updateStatus).to.equal('fail');
   });
 
-  it('submit button is hidden when PayPal is the selected provider', async () => {
+  it('submit button is visible but disabled until PayPal authorizes', async () => {
     const plan = makePlan();
     const el = await fixture<MonthlyGivingCircle>(
       html`<ia-monthly-giving-circle
@@ -387,8 +392,82 @@ describe('Payment method coordination:', () => {
 
     const submitBtn = paymentMethodEl.querySelector(
       '#edit-plan-payment-method-submit',
+    ) as MGCButton;
+    expect(submitBtn).to.exist;
+    expect(submitBtn.isDisabled).to.be.true;
+
+    paymentMethodEl.querySelector('ia-mgc-braintree-manager')!.dispatchEvent(
+      new CustomEvent('PayPalVaultAuthorized', {
+        bubbles: true,
+        detail: {
+          paymentMethodInfo: {
+            description: 'PayPal - donor@example.com',
+            nonce: 'nonce-pp-enable',
+            type: 'PayPalAccount',
+            details: { email: 'donor@example.com' },
+          },
+        },
+      }),
     );
-    expect(submitBtn).to.not.exist;
+    await paymentMethodEl.updateComplete;
+
+    expect(submitBtn.isDisabled).to.not.be.true;
+  });
+
+  it('submit button is shown but disabled when no provider is selected', async () => {
+    const plan = makePlan();
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+
+    await navigateToEditView(el);
+
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    paymentMethodEl.currentlyEditing = true;
+    // no selectedPaymentProvider set — nothing chosen yet
+    await paymentMethodEl.updateComplete;
+
+    const submitBtn = paymentMethodEl.querySelector(
+      '#edit-plan-payment-method-submit',
+    ) as MGCButton | null;
+    expect(submitBtn).to.exist;
+    expect(submitBtn?.isDisabled).to.be.true;
+  });
+
+  it('submit button is shown and enabled when Credit Card is selected', async () => {
+    const plan = makePlan();
+    const el = await fixture<MonthlyGivingCircle>(
+      html`<ia-monthly-giving-circle
+        .canEdit=${true}
+        .canEditPaymentMethod=${true}
+        .plans=${[plan]}
+      ></ia-monthly-giving-circle>`,
+    );
+
+    await navigateToEditView(el);
+
+    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
+    const paymentMethodEl = editPlan.querySelector(
+      'ia-mgc-edit-payment-method',
+    ) as MGCEditPaymentMethod;
+
+    paymentMethodEl.currentlyEditing = true;
+    paymentMethodEl.selectedPaymentProvider = PaymentProvider.CreditCard;
+    await paymentMethodEl.updateComplete;
+
+    const submitBtn = paymentMethodEl.querySelector(
+      '#edit-plan-payment-method-submit',
+    ) as MGCButton | null;
+    expect(submitBtn).to.exist;
+    expect(submitBtn?.isDisabled).to.not.be.true;
   });
 
   it('selecting Google Pay sets selectedPaymentProvider to PaymentProvider.GooglePay', async () => {
@@ -486,7 +565,7 @@ describe('Payment method coordination:', () => {
     expect(braintreeManagerEl?.classList.contains('hidden')).to.be.false;
   });
 
-  it('GooglePayVaultAuthorized on braintree manager dispatches UpdatePaymentMethod with Google Pay provider', async () => {
+  it('GooglePayVaultAuthorized enables submit; submitting dispatches UpdatePaymentMethod with Google Pay provider', async () => {
     const plan = makePlan();
     const el = await fixture<MonthlyGivingCircle>(
       html`<ia-monthly-giving-circle
@@ -525,6 +604,16 @@ describe('Payment method coordination:', () => {
         },
       }),
     );
+    await paymentMethodEl.updateComplete;
+
+    // Authorization alone does not save — it just enables submit.
+    expect(receivedEvent).to.be.null;
+    const submitBtn = paymentMethodEl.querySelector(
+      '#edit-plan-payment-method-submit',
+    ) as MGCButton;
+    expect(submitBtn.isDisabled).to.not.be.true;
+
+    submitBtn.shadowRoot?.querySelector('button')!.click();
     await el.updateComplete;
 
     expect(receivedEvent).to.not.be.null;
@@ -537,65 +626,6 @@ describe('Payment method coordination:', () => {
     expect(newPaymentMethodRequest.paymentMethodInfo.details.cardType).to.equal(
       'Visa',
     );
-
-    expect(plan.payment?.paymentMethodType).to.equal(PaymentProvider.GooglePay);
-    expect(plan.payment?.cardType).to.equal('Visa');
-    expect(plan.payment?.last4).to.equal('4242');
-  });
-
-  it('GooglePayVaultAuthorized updates the plan model immediately, before any host-level UpdatePaymentMethod handling', async () => {
-    const plan = makePlan();
-    const el = await fixture<MonthlyGivingCircle>(
-      html`<ia-monthly-giving-circle
-        .canEdit=${true}
-        .canEditPaymentMethod=${true}
-        .plans=${[plan]}
-      ></ia-monthly-giving-circle>`,
-    );
-
-    await navigateToEditView(el);
-
-    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
-    const paymentMethodEl = editPlan.querySelector(
-      'ia-mgc-edit-payment-method',
-    ) as MGCEditPaymentMethod;
-
-    paymentMethodEl.currentlyEditing = true;
-    paymentMethodEl.selectedPaymentProvider = PaymentProvider.GooglePay;
-    await paymentMethodEl.updateComplete;
-
-    // No listener for UpdatePaymentMethod / updateReceived here — proving the
-    // model update doesn't depend on the host's async round-trip.
-    paymentMethodEl.querySelector('ia-mgc-braintree-manager')!.dispatchEvent(
-      new CustomEvent('GooglePayVaultAuthorized', {
-        bubbles: true,
-        detail: {
-          paymentMethodInfo: {
-            description: 'Google Pay - Mastercard - 9999',
-            nonce: 'nonce-gp-immediate',
-            type: 'AndroidPayCard',
-            details: { cardType: 'Mastercard', lastFour: '9999' },
-          },
-        },
-      }),
-    );
-
-    expect(plan.payment?.paymentMethodType).to.equal(PaymentProvider.GooglePay);
-    expect(plan.payment?.cardType).to.equal('Mastercard');
-    expect(plan.payment?.last4).to.equal('9999');
-    expect(plan.payment?.expirationMonth).to.be.null;
-    expect(plan.payment?.expirationYear).to.be.null;
-
-    await navigateBackToPlans(el);
-
-    const mgcPlans = el.querySelector('ia-mgc-plans') as IauxMgcPlans;
-    await mgcPlans.updateComplete;
-    const detailsText =
-      mgcPlans.shadowRoot?.querySelector('.payment-details')?.textContent ?? '';
-    expect(detailsText).to.include('Mastercard');
-    expect(detailsText).to.include('...9999');
-    expect(detailsText).to.not.include('Expires');
-    expect(detailsText).to.not.include('not found');
   });
 
   it('GooglePayError on braintree manager sets updateStatus to fail', async () => {
@@ -630,7 +660,7 @@ describe('Payment method coordination:', () => {
     expect(paymentMethodEl.updateStatus).to.equal('fail');
   });
 
-  it('submit button is hidden when Google Pay is the selected provider', async () => {
+  it('submit button is visible but disabled until Google Pay authorizes', async () => {
     const plan = makePlan();
     const el = await fixture<MonthlyGivingCircle>(
       html`<ia-monthly-giving-circle
@@ -653,8 +683,26 @@ describe('Payment method coordination:', () => {
 
     const submitBtn = paymentMethodEl.querySelector(
       '#edit-plan-payment-method-submit',
+    ) as MGCButton;
+    expect(submitBtn).to.exist;
+    expect(submitBtn.isDisabled).to.be.true;
+
+    paymentMethodEl.querySelector('ia-mgc-braintree-manager')!.dispatchEvent(
+      new CustomEvent('GooglePayVaultAuthorized', {
+        bubbles: true,
+        detail: {
+          paymentMethodInfo: {
+            description: 'Google Pay - Visa - 4242',
+            nonce: 'nonce-gp-enable',
+            type: 'AndroidPayCard',
+            details: { cardType: 'Visa', lastFour: '4242' },
+          },
+        },
+      }),
     );
-    expect(submitBtn).to.not.exist;
+    await paymentMethodEl.updateComplete;
+
+    expect(submitBtn.isDisabled).to.not.be.true;
   });
 
   it('selecting Apple Pay sets selectedPaymentProvider to PaymentProvider.ApplePay', async () => {
@@ -759,7 +807,7 @@ describe('Payment method coordination:', () => {
     expect(braintreeManagerEl?.classList.contains('hidden')).to.be.false;
   });
 
-  it('ApplePayVaultAuthorized on braintree manager dispatches UpdatePaymentMethod with Apple Pay provider', async () => {
+  it('ApplePayVaultAuthorized enables submit; submitting dispatches UpdatePaymentMethod with Apple Pay provider', async () => {
     const plan = makePlan();
     const el = await fixture<MonthlyGivingCircle>(
       html`<ia-monthly-giving-circle
@@ -798,6 +846,16 @@ describe('Payment method coordination:', () => {
         },
       }),
     );
+    await paymentMethodEl.updateComplete;
+
+    // Authorization alone does not save — it just enables submit.
+    expect(receivedEvent).to.be.null;
+    const submitBtn = paymentMethodEl.querySelector(
+      '#edit-plan-payment-method-submit',
+    ) as MGCButton;
+    expect(submitBtn.isDisabled).to.not.be.true;
+
+    submitBtn.shadowRoot?.querySelector('button')!.click();
     await el.updateComplete;
 
     expect(receivedEvent).to.not.be.null;
@@ -810,65 +868,6 @@ describe('Payment method coordination:', () => {
     expect(newPaymentMethodRequest.paymentMethodInfo.details.cardType).to.equal(
       'Visa',
     );
-
-    expect(plan.payment?.paymentMethodType).to.equal(PaymentProvider.ApplePay);
-    expect(plan.payment?.cardType).to.equal('Visa');
-    expect(plan.payment?.last4).to.equal('42');
-  });
-
-  it('ApplePayVaultAuthorized updates the plan model immediately, before any host-level UpdatePaymentMethod handling', async () => {
-    const plan = makePlan();
-    const el = await fixture<MonthlyGivingCircle>(
-      html`<ia-monthly-giving-circle
-        .canEdit=${true}
-        .canEditPaymentMethod=${true}
-        .plans=${[plan]}
-      ></ia-monthly-giving-circle>`,
-    );
-
-    await navigateToEditView(el);
-
-    const editPlan = el.querySelector('ia-mgc-edit-plan') as IauxEditPlanForm;
-    const paymentMethodEl = editPlan.querySelector(
-      'ia-mgc-edit-payment-method',
-    ) as MGCEditPaymentMethod;
-
-    paymentMethodEl.currentlyEditing = true;
-    paymentMethodEl.selectedPaymentProvider = PaymentProvider.ApplePay;
-    await paymentMethodEl.updateComplete;
-
-    // No listener for UpdatePaymentMethod / updateReceived here — proving the
-    // model update doesn't depend on the host's async round-trip.
-    paymentMethodEl.querySelector('ia-mgc-braintree-manager')!.dispatchEvent(
-      new CustomEvent('ApplePayVaultAuthorized', {
-        bubbles: true,
-        detail: {
-          paymentMethodInfo: {
-            description: 'Apple Pay - Mastercard - 99',
-            nonce: 'nonce-ap-immediate',
-            type: 'ApplePayCard',
-            details: { cardType: 'Mastercard', lastTwo: '99' },
-          },
-        },
-      }),
-    );
-
-    expect(plan.payment?.paymentMethodType).to.equal(PaymentProvider.ApplePay);
-    expect(plan.payment?.cardType).to.equal('Mastercard');
-    expect(plan.payment?.last4).to.equal('99');
-    expect(plan.payment?.expirationMonth).to.be.null;
-    expect(plan.payment?.expirationYear).to.be.null;
-
-    await navigateBackToPlans(el);
-
-    const mgcPlans = el.querySelector('ia-mgc-plans') as IauxMgcPlans;
-    await mgcPlans.updateComplete;
-    const detailsText =
-      mgcPlans.shadowRoot?.querySelector('.payment-details')?.textContent ?? '';
-    expect(detailsText).to.include('Mastercard');
-    expect(detailsText).to.include('...99');
-    expect(detailsText).to.not.include('Expires');
-    expect(detailsText).to.not.include('not found');
   });
 
   it('ApplePayError on braintree manager sets updateStatus to fail', async () => {
@@ -903,7 +902,7 @@ describe('Payment method coordination:', () => {
     expect(paymentMethodEl.updateStatus).to.equal('fail');
   });
 
-  it('submit button is hidden when Apple Pay is the selected provider', async () => {
+  it('submit button is visible but disabled until Apple Pay authorizes', async () => {
     const plan = makePlan();
     const el = await fixture<MonthlyGivingCircle>(
       html`<ia-monthly-giving-circle
@@ -926,8 +925,26 @@ describe('Payment method coordination:', () => {
 
     const submitBtn = paymentMethodEl.querySelector(
       '#edit-plan-payment-method-submit',
+    ) as MGCButton;
+    expect(submitBtn).to.exist;
+    expect(submitBtn.isDisabled).to.be.true;
+
+    paymentMethodEl.querySelector('ia-mgc-braintree-manager')!.dispatchEvent(
+      new CustomEvent('ApplePayVaultAuthorized', {
+        bubbles: true,
+        detail: {
+          paymentMethodInfo: {
+            description: 'Apple Pay - Visa - 42',
+            nonce: 'nonce-ap-enable',
+            type: 'ApplePayCard',
+            details: { cardType: 'Visa', lastTwo: '42' },
+          },
+        },
+      }),
     );
-    expect(submitBtn).to.not.exist;
+    await paymentMethodEl.updateComplete;
+
+    expect(submitBtn.isDisabled).to.not.be.true;
   });
 
   it('updateReceived with paymentMethodUpdate success closes payment method form', async () => {
@@ -1066,7 +1083,7 @@ describe('Venmo redirect restoration (firstUpdated):', () => {
     expect(paymentMethodEl.currentlyEditing).to.be.false;
   });
 
-  it('VenmoAuthorized from braintree-manager dispatches UpdatePaymentMethod with Venmo provider', async () => {
+  it('VenmoAuthorized enables submit; submitting dispatches UpdatePaymentMethod with Venmo provider', async () => {
     const plan = makePlan();
     const el = await fixture<MonthlyGivingCircle>(
       html`<ia-monthly-giving-circle
@@ -1105,6 +1122,16 @@ describe('Venmo redirect restoration (firstUpdated):', () => {
         },
       }),
     );
+    await paymentMethodEl.updateComplete;
+
+    // Authorization alone does not save — it just enables submit.
+    expect(receivedEvent).to.be.null;
+    const submitBtn = paymentMethodEl.querySelector(
+      '#edit-plan-payment-method-submit',
+    ) as MGCButton;
+    expect(submitBtn.isDisabled).to.not.be.true;
+
+    submitBtn.shadowRoot?.querySelector('button')!.click();
     await el.updateComplete;
 
     expect(receivedEvent).to.not.be.null;

--- a/test/form-sections/braintree-manager.test.ts
+++ b/test/form-sections/braintree-manager.test.ts
@@ -499,4 +499,177 @@ describe('MGCBraintreeManager', () => {
       expect(errorFired).to.be.true;
     });
   });
+
+  describe('startGooglePayPayment', () => {
+    let sandbox: Sinon.SinonSandbox;
+    let el: MGCBraintreeManager;
+
+    function makeGooglePayInstance({
+      paymentDataRequestResult = {} as any,
+      parseResponseResult = null as any,
+      parseResponseThrows = null as Error | null,
+    } = {}) {
+      return {
+        createPaymentDataRequest: Sinon.stub().resolves(
+          paymentDataRequestResult,
+        ),
+        parseResponse: parseResponseThrows
+          ? Sinon.stub().rejects(parseResponseThrows)
+          : Sinon.stub().resolves(parseResponseResult),
+      };
+    }
+
+    function makeGooglePayHandler({
+      instanceResult = null as any,
+      instanceThrows = null as Error | null,
+      loadPaymentDataResult = {} as any,
+      loadPaymentDataThrows = null as unknown,
+    } = {}) {
+      return {
+        instance: {
+          get: instanceThrows
+            ? Sinon.stub().rejects(instanceThrows)
+            : Sinon.stub().resolves(instanceResult),
+        },
+        paymentsClient: {
+          loadPaymentData: loadPaymentDataThrows
+            ? Sinon.stub().rejects(loadPaymentDataThrows)
+            : Sinon.stub().resolves(loadPaymentDataResult),
+        },
+      };
+    }
+
+    function makeBraintreeManager(handler: any = null) {
+      return {
+        paymentProviders: {
+          googlePayHandler: { get: Sinon.stub().resolves(handler) },
+        },
+      };
+    }
+
+    beforeEach(() => {
+      sandbox = Sinon.createSandbox();
+      el = document.createElement(
+        'ia-mgc-braintree-manager',
+      ) as MGCBraintreeManager;
+      (el as any).plan = { amount: 10 };
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('does nothing when handler is unavailable', async () => {
+      (el as any).braintreeManager = makeBraintreeManager(null);
+
+      let eventFired = false;
+      el.addEventListener('GooglePayVaultAuthorized', () => {
+        eventFired = true;
+      });
+
+      await el.startGooglePayPayment();
+
+      expect(eventFired).to.be.false;
+    });
+
+    it('does nothing when instance is unavailable', async () => {
+      const handler = makeGooglePayHandler({ instanceResult: null });
+      (el as any).braintreeManager = makeBraintreeManager(handler);
+
+      let eventFired = false;
+      el.addEventListener('GooglePayVaultAuthorized', () => {
+        eventFired = true;
+      });
+
+      await el.startGooglePayPayment();
+
+      expect(eventFired).to.be.false;
+      expect(handler.paymentsClient.loadPaymentData.called).to.be.false;
+    });
+
+    it('dispatches GooglePayVaultAuthorized with correct payload on success', async () => {
+      const payload = {
+        nonce: 'fake-nonce',
+        type: 'AndroidPayCard',
+        details: { cardType: 'Visa', lastFour: '1234' },
+      };
+      const instance = makeGooglePayInstance({ parseResponseResult: payload });
+      const handler = makeGooglePayHandler({ instanceResult: instance });
+      (el as any).braintreeManager = makeBraintreeManager(handler);
+
+      let authorizedDetail: any = null;
+      el.addEventListener('GooglePayVaultAuthorized', (e: Event) => {
+        authorizedDetail = (e as CustomEvent).detail;
+      });
+
+      await el.startGooglePayPayment();
+
+      expect(authorizedDetail).to.not.be.null;
+      expect(authorizedDetail.paymentMethodInfo.nonce).to.equal('fake-nonce');
+      expect(authorizedDetail.paymentMethodInfo.description).to.equal(
+        'Google Pay - Visa - 1234',
+      );
+      expect(authorizedDetail.paymentMethodInfo.details.cardType).to.equal(
+        'Visa',
+      );
+      expect(authorizedDetail.paymentMethodInfo.details.lastFour).to.equal(
+        '1234',
+      );
+    });
+
+    it('dispatches GooglePayError when the Braintree Google Pay client fails to initialize', async () => {
+      const handler = makeGooglePayHandler({
+        instanceThrows: new Error(
+          'Google Pay is not enabled for this merchant',
+        ),
+      });
+      (el as any).braintreeManager = makeBraintreeManager(handler);
+
+      let errorFired = false;
+      el.addEventListener('GooglePayError', () => {
+        errorFired = true;
+      });
+
+      await el.startGooglePayPayment();
+
+      expect(errorFired).to.be.true;
+    });
+
+    it('does not dispatch GooglePayError when the user cancels', async () => {
+      const cancelErr = { statusCode: 'CANCELED' };
+      const instance = makeGooglePayInstance();
+      const handler = makeGooglePayHandler({
+        instanceResult: instance,
+        loadPaymentDataThrows: cancelErr,
+      });
+      (el as any).braintreeManager = makeBraintreeManager(handler);
+
+      let errorFired = false;
+      el.addEventListener('GooglePayError', () => {
+        errorFired = true;
+      });
+
+      await el.startGooglePayPayment();
+
+      expect(errorFired).to.be.false;
+    });
+
+    it('dispatches GooglePayError on unexpected error', async () => {
+      const instance = makeGooglePayInstance();
+      const handler = makeGooglePayHandler({
+        instanceResult: instance,
+        loadPaymentDataThrows: new Error('Network error'),
+      });
+      (el as any).braintreeManager = makeBraintreeManager(handler);
+
+      let errorFired = false;
+      el.addEventListener('GooglePayError', () => {
+        errorFired = true;
+      });
+
+      await el.startGooglePayPayment();
+
+      expect(errorFired).to.be.true;
+    });
+  });
 });

--- a/test/form-sections/braintree-manager.test.ts
+++ b/test/form-sections/braintree-manager.test.ts
@@ -672,4 +672,217 @@ describe('MGCBraintreeManager', () => {
       expect(errorFired).to.be.true;
     });
   });
+
+  describe('startApplePayPayment', () => {
+    let sandbox: Sinon.SinonSandbox;
+    let el: MGCBraintreeManager;
+    let originalApplePaySession: unknown;
+
+    class MockApplePaySession {
+      static STATUS_SUCCESS = 1;
+
+      static STATUS_FAILURE = 2;
+
+      static lastInstance: any;
+
+      onvalidatemerchant: ((event: any) => void) | undefined;
+
+      onpaymentauthorized: ((event: any) => void) | undefined;
+
+      oncancel: (() => void) | undefined;
+
+      completeMerchantValidation = Sinon.stub();
+
+      abort = Sinon.stub();
+
+      begin = Sinon.stub();
+
+      completePayment = Sinon.stub();
+
+      constructor(
+        public version: number,
+        public paymentRequest: any,
+      ) {
+        MockApplePaySession.lastInstance = this;
+      }
+    }
+
+    function makeApplePayInstance({
+      createPaymentRequestResult = {} as any,
+      performValidationImpl = undefined as Sinon.SinonStub | undefined,
+      tokenizeResult = null as any,
+      tokenizeThrows = null as Error | null,
+    } = {}) {
+      return {
+        createPaymentRequest: Sinon.stub().returns(createPaymentRequestResult),
+        performValidation:
+          performValidationImpl ??
+          Sinon.stub().callsFake((_options: any, cb: any) => cb(null, {})),
+        tokenize: tokenizeThrows
+          ? Sinon.stub().rejects(tokenizeThrows)
+          : Sinon.stub().resolves(tokenizeResult),
+      };
+    }
+
+    function makeApplePayHandler({
+      instanceResult = null as any,
+      instanceThrows = null as Error | null,
+    } = {}) {
+      return {
+        instance: {
+          get: instanceThrows
+            ? Sinon.stub().rejects(instanceThrows)
+            : Sinon.stub().resolves(instanceResult),
+        },
+      };
+    }
+
+    function makeBraintreeManager(handler: any = null) {
+      return {
+        paymentProviders: {
+          applePayHandler: { get: Sinon.stub().resolves(handler) },
+        },
+      };
+    }
+
+    beforeEach(() => {
+      sandbox = Sinon.createSandbox();
+      el = document.createElement(
+        'ia-mgc-braintree-manager',
+      ) as MGCBraintreeManager;
+      (el as any).plan = { amount: 10 };
+      originalApplePaySession = (window as any).ApplePaySession;
+      (window as any).ApplePaySession = MockApplePaySession;
+      MockApplePaySession.lastInstance = undefined;
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+      (window as any).ApplePaySession = originalApplePaySession;
+    });
+
+    it('does nothing when handler is unavailable', async () => {
+      (el as any).braintreeManager = makeBraintreeManager(null);
+
+      await el.startApplePayPayment(new Event('click'));
+
+      expect(MockApplePaySession.lastInstance).to.be.undefined;
+    });
+
+    it('does nothing when applePayInstance is unavailable', async () => {
+      const handler = makeApplePayHandler({ instanceResult: null });
+      (el as any).braintreeManager = makeBraintreeManager(handler);
+
+      await el.startApplePayPayment(new Event('click'));
+
+      expect(MockApplePaySession.lastInstance).to.be.undefined;
+    });
+
+    it('dispatches ApplePayVaultAuthorized with correct payload on success', async () => {
+      const payload = {
+        nonce: 'fake-nonce',
+        type: 'ApplePayCard',
+        details: { cardType: 'Visa', dpanLastTwo: '42' },
+      };
+      const applePayInstance = makeApplePayInstance({
+        tokenizeResult: payload,
+      });
+      const handler = makeApplePayHandler({ instanceResult: applePayInstance });
+      (el as any).braintreeManager = makeBraintreeManager(handler);
+
+      let authorizedDetail: any = null;
+      el.addEventListener('ApplePayVaultAuthorized', (e: Event) => {
+        authorizedDetail = (e as CustomEvent).detail;
+      });
+
+      await el.startApplePayPayment(new Event('click'));
+
+      const session = MockApplePaySession.lastInstance!;
+      expect(session.begin.called).to.be.true;
+
+      // Simulate Apple's merchant validation callback
+      await session.onvalidatemerchant!({ validationURL: 'https://apple.com' });
+      expect(applePayInstance.performValidation.called).to.be.true;
+      expect(session.completeMerchantValidation.calledWith({})).to.be.true;
+
+      // Simulate Apple's payment authorization callback
+      await session.onpaymentauthorized!({ payment: { token: 'fake-token' } });
+
+      expect(applePayInstance.tokenize.calledWith({ token: 'fake-token' })).to
+        .be.true;
+      expect(
+        session.completePayment.calledWith(MockApplePaySession.STATUS_SUCCESS),
+      ).to.be.true;
+      expect(authorizedDetail).to.not.be.null;
+      expect(authorizedDetail.paymentMethodInfo.nonce).to.equal('fake-nonce');
+      expect(authorizedDetail.paymentMethodInfo.details.cardType).to.equal(
+        'Visa',
+      );
+      expect(authorizedDetail.paymentMethodInfo.details.lastTwo).to.equal('42');
+    });
+
+    it('aborts the session and dispatches ApplePayError when merchant validation fails', async () => {
+      const validationErr = new Error('validation failed');
+      const applePayInstance = makeApplePayInstance({
+        performValidationImpl: Sinon.stub().callsFake(
+          (_options: any, cb: any) => cb(validationErr, null),
+        ),
+      });
+      const handler = makeApplePayHandler({ instanceResult: applePayInstance });
+      (el as any).braintreeManager = makeBraintreeManager(handler);
+
+      let errorFired = false;
+      el.addEventListener('ApplePayError', () => {
+        errorFired = true;
+      });
+
+      await el.startApplePayPayment(new Event('click'));
+
+      const session = MockApplePaySession.lastInstance!;
+      await session.onvalidatemerchant!({ validationURL: 'https://apple.com' });
+
+      expect(session.abort.called).to.be.true;
+      expect(session.completeMerchantValidation.called).to.be.false;
+      expect(errorFired).to.be.true;
+    });
+
+    it('completes the session with failure and dispatches ApplePayError when tokenize fails', async () => {
+      const applePayInstance = makeApplePayInstance({
+        tokenizeThrows: new Error('tokenize failed'),
+      });
+      const handler = makeApplePayHandler({ instanceResult: applePayInstance });
+      (el as any).braintreeManager = makeBraintreeManager(handler);
+
+      let errorFired = false;
+      el.addEventListener('ApplePayError', () => {
+        errorFired = true;
+      });
+
+      await el.startApplePayPayment(new Event('click'));
+
+      const session = MockApplePaySession.lastInstance!;
+      await session.onpaymentauthorized!({ payment: { token: 'fake-token' } });
+
+      expect(
+        session.completePayment.calledWith(MockApplePaySession.STATUS_FAILURE),
+      ).to.be.true;
+      expect(errorFired).to.be.true;
+    });
+
+    it('dispatches ApplePayError on unexpected error retrieving the instance', async () => {
+      const handler = makeApplePayHandler({
+        instanceThrows: new Error('SDK unavailable'),
+      });
+      (el as any).braintreeManager = makeBraintreeManager(handler);
+
+      let errorFired = false;
+      el.addEventListener('ApplePayError', () => {
+        errorFired = true;
+      });
+
+      await el.startApplePayPayment(new Event('click'));
+
+      expect(errorFired).to.be.true;
+    });
+  });
 });

--- a/test/models/plan.test.ts
+++ b/test/models/plan.test.ts
@@ -639,5 +639,59 @@ describe('MonthlyPlan', () => {
       expect(mp.plan.btdata.expirationMonth).to.be.null;
       expect(mp.plan.btdata.expirationYear).to.be.null;
     });
+
+    it('sets cardType and last4 (from lastTwo) when switching to Apple Pay provider', () => {
+      const btdata = makeBtData({
+        paymentMethodType: 'Venmo',
+        venmoUsername: '@donor',
+        last4: null,
+        cardType: null,
+      });
+      const mp = new MonthlyPlan(makePlan({ btdata }));
+
+      const request = new PaymentMethodRequest({
+        paymentMethodInfo: {
+          description: 'Apple Pay - Visa - 42',
+          nonce: 'nonce_applepay',
+          type: 'ApplePayCard',
+          details: { cardType: 'Visa', lastTwo: '42' },
+        },
+        donorContactInfo: {},
+        paymentProvider: PaymentProvider.ApplePay,
+      });
+
+      mp.setNewPaymentMethod(request);
+
+      expect(mp.plan.btdata.paymentMethodType).to.equal('Apple Pay');
+      expect(mp.plan.btdata.cardType).to.equal('Visa');
+      expect(mp.plan.btdata.last4).to.equal('42');
+    });
+
+    it('Apple Pay branch clears expirationMonth and expirationYear', () => {
+      const btdata = makeBtData({
+        paymentMethodType: 'creditCard',
+        last4: '1234',
+        cardType: 'Visa',
+        expirationMonth: '12',
+        expirationYear: '2025',
+      });
+      const mp = new MonthlyPlan(makePlan({ btdata }));
+
+      const request = new PaymentMethodRequest({
+        paymentMethodInfo: {
+          description: 'Apple Pay - Visa - 42',
+          nonce: 'nonce_applepay',
+          type: 'ApplePayCard',
+          details: { cardType: 'Visa', lastTwo: '42' },
+        },
+        donorContactInfo: {},
+        paymentProvider: PaymentProvider.ApplePay,
+      });
+
+      mp.setNewPaymentMethod(request);
+
+      expect(mp.plan.btdata.expirationMonth).to.be.null;
+      expect(mp.plan.btdata.expirationYear).to.be.null;
+    });
   });
 });

--- a/test/models/plan.test.ts
+++ b/test/models/plan.test.ts
@@ -585,5 +585,59 @@ describe('MonthlyPlan', () => {
       expect(mp.plan.btdata.expirationMonth).to.be.null;
       expect(mp.plan.btdata.expirationYear).to.be.null;
     });
+
+    it('sets cardType and last4 when switching to Google Pay provider', () => {
+      const btdata = makeBtData({
+        paymentMethodType: 'Venmo',
+        venmoUsername: '@donor',
+        last4: null,
+        cardType: null,
+      });
+      const mp = new MonthlyPlan(makePlan({ btdata }));
+
+      const request = new PaymentMethodRequest({
+        paymentMethodInfo: {
+          description: 'Google Pay - Visa - 4242',
+          nonce: 'nonce_googlepay',
+          type: 'AndroidPayCard',
+          details: { cardType: 'Visa', lastFour: '4242' },
+        },
+        donorContactInfo: {},
+        paymentProvider: PaymentProvider.GooglePay,
+      });
+
+      mp.setNewPaymentMethod(request);
+
+      expect(mp.plan.btdata.paymentMethodType).to.equal('Google Pay');
+      expect(mp.plan.btdata.cardType).to.equal('Visa');
+      expect(mp.plan.btdata.last4).to.equal('4242');
+    });
+
+    it('Google Pay branch clears expirationMonth and expirationYear', () => {
+      const btdata = makeBtData({
+        paymentMethodType: 'creditCard',
+        last4: '1234',
+        cardType: 'Visa',
+        expirationMonth: '12',
+        expirationYear: '2025',
+      });
+      const mp = new MonthlyPlan(makePlan({ btdata }));
+
+      const request = new PaymentMethodRequest({
+        paymentMethodInfo: {
+          description: 'Google Pay - Visa - 4242',
+          nonce: 'nonce_googlepay',
+          type: 'AndroidPayCard',
+          details: { cardType: 'Visa', lastFour: '4242' },
+        },
+        donorContactInfo: {},
+        paymentProvider: PaymentProvider.GooglePay,
+      });
+
+      mp.setNewPaymentMethod(request);
+
+      expect(mp.plan.btdata.expirationMonth).to.be.null;
+      expect(mp.plan.btdata.expirationYear).to.be.null;
+    });
   });
 });

--- a/test/plans-payment-method-display.test.ts
+++ b/test/plans-payment-method-display.test.ts
@@ -1,0 +1,106 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { html, fixture, expect } from '@open-wc/testing';
+import { PaymentProvider } from '@internetarchive/donation-form-data-models';
+
+import type { MonthlyGivingCircle } from '../src/monthly-giving-circle';
+import type { IauxMgcPlans } from '../src/plans';
+import { MonthlyPlan } from '../src/models/plan';
+import type { BtData } from '../src/models/plan';
+
+import '../src/monthly-giving-circle';
+
+function makePlanWithPayment(btdataOverrides: Partial<BtData>): MonthlyPlan {
+  return new MonthlyPlan({
+    token: 'test-token',
+    amount: 10,
+    currency: 'USD',
+    start_date: '2024-07-01 00:00:00',
+    is_test: true,
+    btdata: {
+      billingDayOfMonth: 15,
+      nextBillingDate: {
+        date: '2024-08-15 00:00:00.000000',
+        timezone_type: 3,
+        timezone: 'UTC',
+      },
+      status: 'Active',
+      // Real backend/legacy data uses this exact lowercase-camel casing (see
+      // demo/data.json), not the PaymentProvider.CreditCard enum string
+      // ('Credit Card') — matching it here keeps this fixture representative.
+      paymentMethodType: 'creditCard',
+      last4: '1234',
+      cardType: 'Visa',
+      expirationMonth: '12',
+      expirationYear: '2025',
+      ...btdataOverrides,
+    },
+  });
+}
+
+async function renderPlansFor(plan: MonthlyPlan): Promise<IauxMgcPlans> {
+  const el = await fixture<MonthlyGivingCircle>(
+    html`<ia-monthly-giving-circle
+      .canEdit=${true}
+      .plans=${[plan]}
+    ></ia-monthly-giving-circle>`,
+  );
+  const mgcPlans = el.querySelector('ia-mgc-plans') as IauxMgcPlans;
+  await mgcPlans.updateComplete;
+  return mgcPlans;
+}
+
+describe('Plans view payment method display:', () => {
+  it('Google Pay plan shows cardType and last4, and no Expires text', async () => {
+    const plan = makePlanWithPayment({
+      paymentMethodType: PaymentProvider.GooglePay,
+      cardType: 'Mastercard',
+      last4: '9999',
+      expirationMonth: null,
+      expirationYear: null,
+    });
+    const mgcPlans = await renderPlansFor(plan);
+    const detailsText =
+      mgcPlans.shadowRoot?.querySelector('.payment-details')?.textContent ?? '';
+
+    expect(detailsText).to.include('Mastercard');
+    expect(detailsText).to.include('...9999');
+    expect(detailsText).to.not.include('Expires');
+    expect(detailsText).to.not.include('not found');
+  });
+
+  it('credit card plan shows cardType, last4, and real Expires text', async () => {
+    // Uses the real backend casing ('creditCard'), not the PaymentProvider
+    // enum string — the cardType/last4 line is now shown based on value
+    // presence rather than matching paymentMethodType, so it's robust to
+    // that casing difference.
+    const plan = makePlanWithPayment({});
+    const mgcPlans = await renderPlansFor(plan);
+    const detailsText =
+      mgcPlans.shadowRoot?.querySelector('.payment-details')?.textContent ?? '';
+
+    expect(detailsText).to.include('Credit card');
+    expect(detailsText).to.include('Visa');
+    expect(detailsText).to.include('...1234');
+    expect(detailsText).to.include('Expires:');
+    expect(detailsText).to.include('12/2025');
+    expect(detailsText).to.not.include('not found');
+  });
+
+  it('PayPal plan does not show a cardType/last4 line', async () => {
+    const plan = makePlanWithPayment({
+      paymentMethodType: PaymentProvider.PayPal,
+      cardType: null,
+      last4: null,
+      expirationMonth: null,
+      expirationYear: null,
+      paypalEmail: 'donor@example.com',
+    });
+    const mgcPlans = await renderPlansFor(plan);
+    const detailsText =
+      mgcPlans.shadowRoot?.querySelector('.payment-details')?.textContent ?? '';
+
+    expect(detailsText).to.include('Paypal email');
+    expect(detailsText).to.not.include('CC number not found');
+    expect(detailsText).to.not.include('Card type not found');
+  });
+});

--- a/test/plans-payment-method-display.test.ts
+++ b/test/plans-payment-method-display.test.ts
@@ -86,6 +86,24 @@ describe('Plans view payment method display:', () => {
     expect(detailsText).to.not.include('not found');
   });
 
+  it('Apple Pay plan shows cardType and last4 (2 digits), and no Expires text', async () => {
+    const plan = makePlanWithPayment({
+      paymentMethodType: PaymentProvider.ApplePay,
+      cardType: 'Visa',
+      last4: '42',
+      expirationMonth: null,
+      expirationYear: null,
+    });
+    const mgcPlans = await renderPlansFor(plan);
+    const detailsText =
+      mgcPlans.shadowRoot?.querySelector('.payment-details')?.textContent ?? '';
+
+    expect(detailsText).to.include('Visa');
+    expect(detailsText).to.include('...42');
+    expect(detailsText).to.not.include('Expires');
+    expect(detailsText).to.not.include('not found');
+  });
+
   it('PayPal plan does not show a cardType/last4 line', async () => {
     const plan = makePlanWithPayment({
       paymentMethodType: PaymentProvider.PayPal,

--- a/test/plans-payment-method-display.test.ts
+++ b/test/plans-payment-method-display.test.ts
@@ -120,5 +120,25 @@ describe('Plans view payment method display:', () => {
     expect(detailsText).to.include('Paypal email');
     expect(detailsText).to.not.include('CC number not found');
     expect(detailsText).to.not.include('Card type not found');
+    expect(detailsText).to.not.include('Expires');
+    expect(detailsText).to.not.include('not found');
+  });
+
+  it('Venmo plan does not show an Expires line', async () => {
+    const plan = makePlanWithPayment({
+      paymentMethodType: PaymentProvider.Venmo,
+      cardType: null,
+      last4: null,
+      expirationMonth: null,
+      expirationYear: null,
+      venmoUsername: 'donor-venmo',
+    });
+    const mgcPlans = await renderPlansFor(plan);
+    const detailsText =
+      mgcPlans.shadowRoot?.querySelector('.payment-details')?.textContent ?? '';
+
+    expect(detailsText).to.include('Venmo username');
+    expect(detailsText).to.not.include('Expires');
+    expect(detailsText).to.not.include('not found');
   });
 });


### PR DESCRIPTION
https://internetarchive.github.io/iaux-monthly-giving-circle/pr/pr-80/demo/

- Google Pay
  - chrome browser with an active google pay -> sees option in payment method
  - without google pay -> Check the "force show + simulate" button -> sees option in payment method
- Apple Pay
  - safari browser with an active apple pay -> sees option in payment method
  - without apple pay -> Check the "force show + simulate" button -> sees option in payment method
  
<img width="1233" height="645" alt="image" src="https://github.com/user-attachments/assets/f5b215df-1327-4003-855e-211fffc9a49c" />
